### PR TITLE
Use maplibre demo sprite and glyphs

### DIFF
--- a/client/src/containers/section/map/map-style.json
+++ b/client/src/containers/section/map/map-style.json
@@ -117,5 +117,5 @@
       }
     }
   ],
-  "id": "osm-liberty"
+  "id": "orcasa-style"
 }

--- a/client/src/containers/section/map/map-style.json
+++ b/client/src/containers/section/map/map-style.json
@@ -1,10 +1,7 @@
 {
   "version": 8,
-  "name": "OSM Liberty",
+  "name": "Orcasa",
   "metadata": {
-    "maputnik:license": "https://github.com/maputnik/osm-liberty/blob/gh-pages/LICENSE.md",
-    "maputnik:renderer": "mbgljs",
-    "openmaptiles:version": "3.x",
     "groups": {
       "basemap-satellite": {
           "name": "basemap-satellite",
@@ -55,8 +52,8 @@
       "type": "geojson"
     }
   },
-  "sprite": "https://maputnik.github.io/osm-liberty/sprites/osm-liberty",
-  "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=8k3OpweQg8O0TfOOUwcF",
+  "sprite": "https://demotiles.maplibre.org/styles/osm-bright-gl-style/sprite",
+  "glyphs": "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",


### PR DESCRIPTION
Use sprite and glyphs from Maplibre demo. This makes us independent from any service that is not open-source or requires an API as we don't need anything more in our base map style.