### PR TITLE
Feature/open detail on map click

### DIFF
--- a/client/src/components/map/networks-popup/index.tsx
+++ b/client/src/components/map/networks-popup/index.tsx
@@ -4,7 +4,7 @@ import { useSetRecoilState } from 'recoil';
 
 import { cn } from '@/lib/classnames';
 
-import { networkDetailAtom } from '@/store';
+import { networkDetailAtom, sidebarOpenAtom } from '@/store';
 
 import { OrganizationProperties, ProjectProperties } from '@/hooks/networks';
 
@@ -26,8 +26,8 @@ type NetworksPopupProps = {
 };
 
 const NetworksPopup = ({ popup, setPopup }: NetworksPopupProps) => {
-  const setMapSettings = useSetRecoilState(networkDetailAtom);
-
+  const setDetailPanel = useSetRecoilState(networkDetailAtom);
+  const setSidebarOpen = useSetRecoilState(sidebarOpenAtom);
   if (!popup) return null;
   const {
     type,
@@ -68,7 +68,10 @@ const NetworksPopup = ({ popup, setPopup }: NetworksPopupProps) => {
                 className={cn('text-left text-base font-semibold', networkClass)}
                 size="asChild"
                 variant="vanilla"
-                onClick={() => setMapSettings({ id, type, name })}
+                onClick={() => {
+                  setDetailPanel({ id, type, name });
+                  setSidebarOpen(true);
+                }}
               >
                 {network.name}
               </Button>


### PR DESCRIPTION
This is a fix for a functionality need described here: https://vizzuality.atlassian.net/browse/ORC-121?focusedCommentId=26342&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-26342

When we click on a link inside the popup of a network marker and the sidebar is closed we should open the sidebar