### PR TITLE
Fix issues related with the basemaps

### DIFF
--- a/client/src/containers/default-basemap/index.tsx
+++ b/client/src/containers/default-basemap/index.tsx
@@ -24,9 +24,10 @@ export default function DefaultBasemap() {
 
   // When `basePreviousPathname` equals to `null`, it means that the user directly landed on the
   // page (without any client-side navigation)
-  const hasChangedModule = basePathname !== basePreviousPathname && basePreviousPathname !== null;
+  const isDirectAccess = basePreviousPathname === null;
+  const hasChangedModule = basePathname !== basePreviousPathname && !isDirectAccess;
 
-  const [, setMapSettings] = useMapSettings();
+  const [mapSettings, setMapSettings] = useMapSettings();
 
   useEffect(() => {
     const updateBasemap = async () => {
@@ -46,10 +47,10 @@ export default function DefaultBasemap() {
       }));
     };
 
-    if (hasChangedModule) {
+    if (hasChangedModule || (isDirectAccess && !mapSettings.basemap)) {
       updateBasemap();
     }
-  }, [hasChangedModule, basePathname, setMapSettings]);
+  }, [isDirectAccess, hasChangedModule, basePathname, setMapSettings, mapSettings.basemap]);
 
   return null;
 }

--- a/client/src/containers/map/map-style.json
+++ b/client/src/containers/map/map-style.json
@@ -38,8 +38,7 @@
         "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
       ],
       "maxzoom": 12,
-      "minzoom": 1,
-      "layout": { "visibility": "none" }
+      "minzoom": 1
     },
     "basemap-light": {
       "type": "raster",
@@ -48,8 +47,7 @@
         "https://a.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png"
       ],
       "maxzoom": 12,
-      "minzoom": 1,
-      "layout": { "visibility": "none" }
+      "minzoom": 1
     },
     "basemap-relief": {
       "type": "raster",
@@ -58,8 +56,7 @@
         "https://server.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}"
       ],
       "maxzoom": 12,
-      "minzoom": 1,
-      "layout": { "visibility": "none" }
+      "minzoom": 1
     },
     "labels": {
       "data": "/country_labels.json",
@@ -80,19 +77,22 @@
       "id": "basemap-satellite",
       "type": "raster",
       "source": "basemap-satellite",
-      "metadata": {"group": "basemap-satellite"}
+      "metadata": {"group": "basemap-satellite"},
+      "layout": { "visibility": "none" }
     },
     {
       "id": "basemap-light",
       "type": "raster",
       "source": "basemap-light",
-      "metadata": {"group": "basemap-light"}
+      "metadata": {"group": "basemap-light"},
+      "layout": { "visibility": "none" }
     },
     {
       "id": "basemap-relief",
       "type": "raster",
       "source": "basemap-relief",
-      "metadata": {"group": "basemap-relief"}
+      "metadata": {"group": "basemap-relief"},
+      "layout": { "visibility": "none" }
     },
     {
       "id": "custom-layers",

--- a/client/src/containers/map/settings/manager/index.tsx
+++ b/client/src/containers/map/settings/manager/index.tsx
@@ -58,7 +58,9 @@ const MapSettingsManager = () => {
   );
 
   const handleStyleLoad = useCallback(() => {
-    handleGroup(['basemap'], basemap);
+    if (basemap) {
+      handleGroup(['basemap'], basemap);
+    }
     handleGroup(['labels'], `labels-${labels ?? LABELS[0].slug}`, labels !== null);
   }, [basemap, labels, handleGroup]);
 
@@ -75,7 +77,9 @@ const MapSettingsManager = () => {
   // * handle basemap, labels
   useEffect(() => {
     if (!mapRef) return;
-    handleGroup(['basemap'], basemap);
+    if (basemap) {
+      handleGroup(['basemap'], basemap);
+    }
     handleGroup(['labels'], `labels-${labels ?? LABELS[0].slug}`, labels !== null);
   }, [mapRef, loaded, basemap, labels, handleGroup]);
 

--- a/client/src/hooks/ui/theme.ts
+++ b/client/src/hooks/ui/theme.ts
@@ -24,5 +24,5 @@ export function useTheme(prefix?: string): DefaultVariant | OpenerVariant | Text
   };
   const [{ basemap }] = useMapSettings();
 
-  return variants[basemap][prefix || 'default'];
+  return variants[basemap ?? 'basemap-light'][prefix || 'default'];
 }

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -12,8 +12,7 @@ import { MapLayerMouseEvent } from 'react-map-gl/maplibre';
 export const useMapSettings = () => {
   return useQueryState(
     'map-settings',
-    parseAsJson<{ basemap: string; labels: string | null }>().withDefault({
-      basemap: 'basemap-satellite',
+    parseAsJson<{ basemap?: string; labels: string | null }>().withDefault({
       labels: null,
     }),
   );


### PR DESCRIPTION
This PR ensures that the correct default basemap is displayed on each module and that the map doesn't flash multiple basemaps when loading.

## How to test

### Steps to reproduce

1. Open the [Geospatial Data](https://staging.orcasa.dev-vizzuality.com/geospatial-data) module
  a. Notice what the map displays when it’s loading
2. Open the [Network](https://staging.orcasa.dev-vizzuality.com/network) module (hard load)
	a. Notice the basemap

### Result

When loading, several basemaps flashes on the map of the Geospatial Data module.

When loaded through a direct link, the Network module uses the satellite view as a default basemap.

### Expected result

When loading, only the satellite basemap appears on the Geospatial Data module.

When loaded through a direct link, the Network module uses the relief basemap.

## Tracking

[ORC-135](https://vizzuality.atlassian.net/browse/ORC-135)