### PR TITLE
Feature/map network filter

### DIFF
--- a/client/src/components/map/controls/settings/index.tsx
+++ b/client/src/components/map/controls/settings/index.tsx
@@ -2,7 +2,6 @@
 
 import { FC } from 'react';
 
-import { PopoverArrow } from '@radix-ui/react-popover';
 import { TooltipPortal } from '@radix-ui/react-tooltip';
 import { Settings, X } from 'lucide-react';
 

--- a/client/src/components/map/layers/networks-markers/index.tsx
+++ b/client/src/components/map/layers/networks-markers/index.tsx
@@ -232,9 +232,8 @@ const NetworkMarkersWithData = ({
   );
 };
 
-const NetworkMarkersMain = () => {
-  return <NetworkMarkersWithData {...useMapNetworks()} />;
-};
+const NetworkMarkersMain = () => <NetworkMarkersWithData {...useMapNetworks()} />;
+
 const NetworkMarkersDetail = (filters: Filters) => (
   <NetworkMarkersWithData {...useMapNetworksWithFilters(filters)} {...filters} />
 );

--- a/client/src/components/map/layers/networks-markers/index.tsx
+++ b/client/src/components/map/layers/networks-markers/index.tsx
@@ -121,10 +121,7 @@ const NetworkMarkersWithData = ({
   id?: number;
 }) => {
   const { current: map } = useMap();
-  const { data: parentNetworkData } = (
-    type === 'organization' ? useGetOrganizationsId : useGetProjectsId
-  )(Number(id));
-  const parentNetworkName = parentNetworkData?.data?.attributes?.name;
+
   const [popup, setPopup] = useState<PopupAttributes>(null);
 
   // Close popup on map click. Important stopPropagation() in MarkerComponent
@@ -156,6 +153,13 @@ const NetworkMarkersWithData = ({
   if (!features || (isFetched && isError) || typeof map === 'undefined') {
     return null;
   }
+
+  if (typeof id === 'undefined') return;
+  const { data: parentNetworkData } = (
+    type === 'organization' ? useGetOrganizationsId : useGetProjectsId
+  )(id);
+
+  const parentNetworkName = parentNetworkData?.data?.attributes?.name;
 
   return (
     <>

--- a/client/src/components/map/layers/networks-markers/index.tsx
+++ b/client/src/components/map/layers/networks-markers/index.tsx
@@ -1,5 +1,7 @@
 import { useState, useMemo, useEffect, useCallback } from 'react';
 
+import { usePathname } from 'next/navigation';
+
 import { Marker, useMap } from 'react-map-gl/maplibre';
 import Supercluster from 'supercluster';
 
@@ -8,7 +10,8 @@ import { format } from '@/lib/utils/formats';
 
 import { LayerProps } from '@/types/layers';
 
-import { OrganizationProperties, ProjectProperties, useMapNetworks } from '@/hooks/networks';
+import { useMapNetworks } from '@/hooks/networks';
+import type { OrganizationProperties, ProjectProperties, Filters } from '@/hooks/networks';
 
 import NetworksPopup, { PopupAttributes } from '@/components/map/networks-popup';
 
@@ -99,7 +102,19 @@ const MarkerComponent = ({
 
 const NetworksMarkers = () => {
   const { current: map } = useMap();
-  const { features, isError, isFetched } = useMapNetworks();
+  const pathname = usePathname();
+  const [, , type, id] = pathname.split('/') || [];
+  const getFilters: () => Filters | undefined = () => {
+    if (typeof id !== 'undefined' && (type === 'project' || type === 'organization')) {
+      return {
+        type,
+        id: Number(id),
+      };
+    } else {
+      return undefined;
+    }
+  };
+  const { features, isError, isFetched } = useMapNetworks(getFilters());
   const [popup, setPopup] = useState<PopupAttributes>(null);
 
   // Close popup on map click. Important stopPropagation() in MarkerComponent

--- a/client/src/components/map/legend/item/toolbar/index.tsx
+++ b/client/src/components/map/legend/item/toolbar/index.tsx
@@ -15,9 +15,10 @@ import {
   TooltipPortal,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import Opacity from '@/styles/icons/opacity.svg';
 
 import Slider from './slider';
+
+import Opacity from '@/styles/icons/opacity.svg';
 
 export const LegendItemToolbar: React.FC<LegendItemToolbarProps> = ({
   settings,

--- a/client/src/components/map/networks-popup/index.tsx
+++ b/client/src/components/map/networks-popup/index.tsx
@@ -25,8 +25,8 @@ type Type = 'project' | 'organization';
 type NetworksPopupProps = {
   popup: PopupAttributes;
   setPopup: (popup: PopupAttributes | null) => void;
-  parentType: Type;
-  parentName: string | undefined;
+  parentType?: Type;
+  parentName?: string | undefined;
 };
 
 const networkDetailSentencePart = (parentType: Type, parentName: string, type: Type) => {

--- a/client/src/components/map/networks-popup/index.tsx
+++ b/client/src/components/map/networks-popup/index.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/classnames';
 
 import { useMapSearchParams, useSidebarOpen } from '@/store';
 
-import { OrganizationProperties, ProjectProperties } from '@/hooks/networks';
+import type { OrganizationProperties, ProjectProperties } from '@/hooks/networks';
 
 import { Button } from '@/components/ui/button';
 export type PopupAttributes = {

--- a/client/src/components/map/networks-popup/index.tsx
+++ b/client/src/components/map/networks-popup/index.tsx
@@ -21,12 +21,36 @@ export type PopupAttributes = {
   };
 } | null;
 
+type Type = 'project' | 'organization';
 type NetworksPopupProps = {
   popup: PopupAttributes;
   setPopup: (popup: PopupAttributes | null) => void;
+  parentType: Type;
+  parentName: string | undefined;
 };
 
-const NetworksPopup = ({ popup, setPopup }: NetworksPopupProps) => {
+const networkDetailSentencePart = (parentType: Type, parentName: string, type: Type) => {
+  if (!parentType) return null;
+  const parentSpan = <span className="font-semibold">{parentName}</span>;
+  if (parentType === 'project')
+    return (
+      <span>
+        {type === 'project' ? <> related to {parentSpan}</> : <> participating in {parentSpan}</>}
+      </span>
+    );
+  if (parentType === 'organization')
+    return (
+      <span>
+        {type === 'project' ? (
+          <> in which {parentSpan} participates</>
+        ) : (
+          <> related to {parentSpan}</>
+        )}
+      </span>
+    );
+};
+
+const NetworksPopup = ({ popup, setPopup, parentType, parentName }: NetworksPopupProps) => {
   const searchParams = useMapSearchParams();
   const [, setSidebarOpen] = useSidebarOpen();
 
@@ -62,6 +86,7 @@ const NetworksPopup = ({ popup, setPopup }: NetworksPopupProps) => {
         <header className="pb-6 text-lg text-slate-700">
           <span>{type === 'project' ? 'Projects coordinated in ' : 'Organisations from '}</span>
           <span className="font-semibold">{countryName}</span>
+          {parentType && parentName && networkDetailSentencePart(parentType, parentName, type)}
         </header>
         <div className="flex max-h-[232px] flex-col items-start justify-start gap-2 overflow-y-auto">
           {networks.map(({ id, name, type }) => (

--- a/client/src/components/network-diagram/item.tsx
+++ b/client/src/components/network-diagram/item.tsx
@@ -8,7 +8,7 @@ import { useMapSearchParams } from '@/store';
 
 import { Organization, Project } from '@/types/generated/strapi.schemas';
 
-import { Category } from '@/hooks/networks';
+import type { Category } from '@/hooks/networks/utils';
 import { useIsOverTwoLines } from '@/hooks/ui/utils';
 
 import { CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -49,8 +49,8 @@ const Path = ({ heightIndex, category, isGranchild = false, isFirstOfType = fals
         }}
       >
         <path
-          d={`M${STROKE_PADDING},${isGranchild ? topHeight - ITEM_HEIGHT : '0'
-            } L${STROKE_PADDING},${topHeight + 20}`}
+          d={`M${STROKE_PADDING},${isGranchild ? topHeight - ITEM_HEIGHT : '0'}
+          L${STROKE_PADDING},${topHeight + 20}`}
           {...pathProps}
         />
         <path

--- a/client/src/hooks/networks/index.ts
+++ b/client/src/hooks/networks/index.ts
@@ -40,7 +40,7 @@ type NetworkProperties = {
   projects: ProjectProperties[];
 };
 
-type PointFeatureWithNetworkProperties = PointFeature<NetworkProperties>;
+export type PointFeatureWithNetworkProperties = PointFeature<NetworkProperties>;
 
 import {
   ORGANIZATION_KEYS,
@@ -233,12 +233,6 @@ const useGetNetwork = () => {
   };
 };
 
-const useGetMapNetworkData = (filters: Filters | undefined) => {
-  const { type } = filters || {};
-  const getNetworksFunction = !!type ? useGetOrganizationsWithFilters : useGetNetwork;
-  return getNetworksFunction(filters);
-};
-
 type NetworkMapResponse = {
   features: PointFeatureWithNetworkProperties[];
   isFetching: boolean;
@@ -252,10 +246,14 @@ export type Filters = {
   id: number | undefined;
 };
 
-export const useMapNetworks: (filters?: Filters) => NetworkMapResponse = (filters) => {
-  const { projectsData, organizationsData, isFetched, isFetching, isPlaceholderData, isError } =
-    useGetMapNetworkData(filters);
-
+const getMapNetworks = ({
+  projectsData,
+  organizationsData,
+  isFetching,
+  isFetched,
+  isPlaceholderData,
+  isError,
+}: ReturnType<typeof useGetNetwork | typeof useGetOrganizationsWithFilters>) => {
   const networks = [...(organizationsData || []), ...(projectsData || [])];
   const groupedNetworks: GroupedNetworks = networks.reduce((acc: GroupedNetworks, network) => {
     const { countryName } = network;
@@ -301,6 +299,10 @@ export const useMapNetworks: (filters?: Filters) => NetworkMapResponse = (filter
     isPlaceholderData,
   };
 };
+
+export const useMapNetworks: () => NetworkMapResponse = () => getMapNetworks(useGetNetwork());
+export const useMapNetworksWithFilters: (filters: Filters) => NetworkMapResponse = (filters) =>
+  getMapNetworks(useGetOrganizationsWithFilters(filters));
 
 export const useNetworkDiagram = ({
   type,

--- a/client/src/hooks/networks/utils.ts
+++ b/client/src/hooks/networks/utils.ts
@@ -116,7 +116,7 @@ export const parseData = (data: Data, type: 'organization' | 'project'): ParsedD
 };
 
 // Get the category of the organization or project for the chart
-const getCategory: (category: ProjectKey | OrganizationKey) => Category = (category) =>
+const getCategory = (category: ProjectKey | OrganizationKey): Category =>
   ({
     lead_projects: 'coordinator',
     partner_projects: 'partner',

--- a/client/src/hooks/networks/utils.ts
+++ b/client/src/hooks/networks/utils.ts
@@ -1,0 +1,155 @@
+import {
+  ProjectListResponseDataItem,
+  ProjectResponse,
+  OrganizationResponse,
+  OrganizationListResponse,
+  OrganizationLeadProjectsDataItem,
+  OrganizationPartnerProjectsDataItem,
+  OrganizationFundedProjectsDataItem,
+  ProjectListResponse,
+  OrganizationListResponseDataItem,
+  ProjectLeadPartnerData,
+  ProjectPartnersDataItem,
+  ProjectFundersDataItem,
+  OrganizationResponseDataObject,
+  ProjectResponseDataObject,
+} from '@/types/generated/strapi.schemas';
+
+export type Category = 'coordinator' | 'partner' | 'funder';
+
+type Data = ProjectListResponse | OrganizationListResponse | undefined;
+
+export const parseData = (data: Data, type: string): ParsedData[] => {
+  if (!data?.data) return [];
+  return data.data
+    ?.map((d) => {
+      const countryData =
+        type === 'organization'
+          ? (d as OrganizationListResponseDataItem).attributes?.country
+          : (d as ProjectListResponseDataItem).attributes?.country_of_coordination;
+      if (!countryData?.data?.attributes) return null;
+      return {
+        id: d.id,
+        type: type,
+        name: d.attributes?.name,
+        countryName: countryData?.data?.attributes?.name,
+        countryLat: countryData?.data?.attributes?.lat,
+        countryLong: countryData?.data?.attributes?.long,
+      };
+    })
+    .filter((d): d is ParsedData => d !== null);
+};
+
+export type ParsedData = {
+  id: number | undefined;
+  type: 'project' | 'organization';
+  name: string | undefined;
+  countryISO: string | undefined;
+  countryName: string | undefined;
+  countryLat: number;
+  countryLong: number;
+};
+
+type OrganizationKey = 'lead_projects' | 'partner_projects' | 'funded_projects';
+type ProjectKey = 'lead_partner' | 'partners' | 'funders';
+
+export const ORGANIZATION_KEYS: OrganizationKey[] = [
+  'lead_projects',
+  'partner_projects',
+  'funded_projects',
+];
+export const PROJECT_KEYS: ProjectKey[] = ['lead_partner', 'partners', 'funders'];
+
+const getCategory: (category: ProjectKey | OrganizationKey) => Category = (category) =>
+  ({
+    lead_projects: 'coordinator',
+    partner_projects: 'partner',
+    funded_projects: 'funder',
+    lead_partner: 'coordinator',
+    partners: 'partner',
+    funders: 'funder',
+  }[category] as Category);
+
+const getProjectData = (
+  key: OrganizationKey,
+  project:
+    | OrganizationLeadProjectsDataItem
+    | OrganizationPartnerProjectsDataItem
+    | OrganizationFundedProjectsDataItem,
+) => ({
+  id: project.id,
+  name: project?.attributes?.name,
+  type: 'project',
+  category: getCategory(key),
+});
+
+const getOrganizationData = (
+  key: ProjectKey,
+  org: ProjectLeadPartnerData | ProjectPartnersDataItem | ProjectFundersDataItem,
+  // Skip the grandparent project so it doesn't show up twice
+  skipProjectId?: number,
+) => ({
+  id: org.id,
+  name: org?.attributes?.name,
+  type: 'organization',
+  category: getCategory(key),
+  children: ORGANIZATION_KEYS.map((organizationKey: OrganizationKey) => {
+    const child = org?.attributes?.[organizationKey]?.data;
+    if (!child) return [];
+    return (Array.isArray(child) ? child : [child]).map(
+      (c) => c.id !== skipProjectId && getProjectData(organizationKey, c),
+    );
+  })
+    .flat()
+    .filter(Boolean),
+});
+
+export const parseOrganization = (organizationData: OrganizationResponse) => {
+  if (!organizationData) return [];
+  const { attributes, id: parentId }: OrganizationResponseDataObject = organizationData?.data || {};
+
+  return ORGANIZATION_KEYS.map((key) => {
+    if (typeof attributes === 'undefined') return null;
+    return attributes[key]?.data?.map(
+      (
+        project:
+          | OrganizationLeadProjectsDataItem
+          | OrganizationPartnerProjectsDataItem
+          | OrganizationFundedProjectsDataItem,
+      ) => ({
+        id: project.id,
+        name: project?.attributes?.name,
+        type: 'project',
+        category: getCategory(key),
+        children: PROJECT_KEYS.map((projectKey: ProjectKey) => {
+          const child = project?.attributes?.[projectKey]?.data;
+          if (!child) return [];
+          return (Array.isArray(child) ? child : [child]).map((c) => {
+            if (c.id !== parentId) return getOrganizationData(projectKey, c);
+          });
+        })
+          .flat()
+          .filter(Boolean),
+      }),
+    );
+  });
+};
+
+export const parseProject = (projectData: ProjectResponse) => {
+  if (!projectData) return [];
+  const { attributes, id: parentProjectId }: ProjectResponseDataObject = projectData?.data || {};
+  return PROJECT_KEYS.map((key) => {
+    if (typeof attributes === 'undefined') {
+      return null;
+    }
+    if (key === 'lead_partner') {
+      if (!attributes[key]?.data) return [];
+      return getOrganizationData(
+        key,
+        attributes[key]?.data as ProjectLeadPartnerData,
+        parentProjectId,
+      );
+    }
+    return attributes[key]?.data?.map((d) => getOrganizationData(key, d, parentProjectId));
+  });
+};

--- a/client/src/hooks/networks/utils.ts
+++ b/client/src/hooks/networks/utils.ts
@@ -21,23 +21,26 @@ type Data = ProjectListResponse | OrganizationListResponse | undefined;
 
 export const parseData = (data: Data, type: string): ParsedData[] => {
   if (!data?.data) return [];
-  return data.data
-    ?.map((d) => {
-      const countryData =
-        type === 'organization'
-          ? (d as OrganizationListResponseDataItem).attributes?.country
-          : (d as ProjectListResponseDataItem).attributes?.country_of_coordination;
-      if (!countryData?.data?.attributes) return null;
-      return {
-        id: d.id,
-        type: type,
-        name: d.attributes?.name,
-        countryName: countryData?.data?.attributes?.name,
-        countryLat: countryData?.data?.attributes?.lat,
-        countryLong: countryData?.data?.attributes?.long,
-      };
-    })
-    .filter((d): d is ParsedData => d !== null);
+  return (
+    data.data &&
+    (Array.isArray(data.data) ? data.data : [data.data])
+      ?.map((d) => {
+        const countryData =
+          type === 'organization'
+            ? (d as OrganizationListResponseDataItem).attributes?.country
+            : (d as ProjectListResponseDataItem).attributes?.country_of_coordination;
+        if (!countryData?.data?.attributes) return null;
+        return {
+          id: d.id,
+          type: type,
+          name: d.attributes?.name,
+          countryName: countryData?.data?.attributes?.name,
+          countryLat: countryData?.data?.attributes?.lat,
+          countryLong: countryData?.data?.attributes?.long,
+        };
+      })
+      .filter((d): d is ParsedData => d !== null)
+  );
 };
 
 export type ParsedData = {

--- a/client/src/hooks/networks/utils.ts
+++ b/client/src/hooks/networks/utils.ts
@@ -13,11 +13,64 @@ import {
   ProjectFundersDataItem,
   OrganizationResponseDataObject,
   ProjectResponseDataObject,
+  ProjectCountryOfCoordinationDataAttributes,
+  OrganizationCountryDataAttributes,
 } from '@/types/generated/strapi.schemas';
 
 export type Category = 'coordinator' | 'partner' | 'funder';
 
 type Data = ProjectListResponse | OrganizationListResponse | undefined;
+
+export const getPopulateForFilters = (type: 'organization' | 'project' | undefined) =>
+  type === 'organization'
+    ? String([
+        'country',
+        'lead_projects.country_of_coordination',
+        'lead_projects.lead_partner.country',
+        'lead_projects.partners.country',
+        'lead_projects.funders.country',
+        'partner_projects.country_of_coordination',
+        'partner_projects.lead_partner.country',
+        'partner_projects.partners.country',
+        'partner_projects.funders.country',
+        'funded_projects.country_of_coordination',
+        'funded_projects.lead_partner.country',
+        'funded_projects.partners.country',
+        'funded_projects.funders.country',
+      ])
+    : String([
+        'country_of_coordination',
+        'lead_partner.country',
+        'lead_partner.lead_projects.country_of_coordination',
+        'lead_partner.partner_projects.country_of_coordination',
+        'lead_partner.funded_projects.country_of_coordination',
+        'partners.country',
+        'partners.lead_project.country_of_coordination',
+        'partners.partner_projects.country_of_coordination',
+        'partners.funded_projects.country_of_coordination',
+        'funders.country',
+        'funders.lead_projects.country_of_coordination',
+        'funders.partner_projects.country_of_coordination',
+        'funders.funded_projects.country_of_coordination',
+      ]);
+
+export const getParsedData: (
+  d:
+    | OrganizationListResponseDataItem
+    | OrganizationLeadProjectsDataItem
+    | ProjectListResponseDataItem
+    | ProjectLeadPartnerData,
+  type: 'organization' | 'project',
+  countryD: OrganizationCountryDataAttributes | ProjectCountryOfCoordinationDataAttributes,
+) => ParsedData = (d, type, countryD) => ({
+  id: d.id,
+  type: type,
+  name: d.attributes?.name,
+  countryISO: countryD?.iso_3,
+  countryName: countryD?.name,
+  countryLat: countryD?.lat || 0,
+  countryLong: countryD?.long || 0,
+});
 
 export const parseData = (data: Data, type: string): ParsedData[] => {
   if (!data?.data) return [];


### PR DESCRIPTION
This PR filters the organizations and projects in the network module when we enter a network detail page.
Also, on the tooltip we change the sentence including the name of the selected network and the appropriate sentence: https://www.figma.com/file/DBXFTLd6nFBmg6fFE6P2cX/ORCaSa-Design-%5BInternal%5D?type=design&node-id=165%3A38016&mode=design&t=sVv5F7tY53GegSjl-1

The component had to be split to avoid conditional rendering of hooks