### PR TITLE
Fix/network detail

### DIFF
--- a/client/src/app/(modules)/network/(details)/layout.tsx
+++ b/client/src/app/(modules)/network/(details)/layout.tsx
@@ -10,7 +10,7 @@ export default function NetworkModuleDetailsLayout({ children }: { children: Rea
   const mapSearchParams = useMapSearchParams();
 
   return (
-    <div className="p-7">
+    <>
       <SlidingLinkButton
         href={`/network?${mapSearchParams.toString()}`}
         Icon={ArrowLeft}
@@ -19,6 +19,6 @@ export default function NetworkModuleDetailsLayout({ children }: { children: Rea
         Back to Results
       </SlidingLinkButton>
       {children}
-    </div>
+    </>
   );
 }

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -41,7 +41,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <Providers>
       <html lang="en">
-        <body className={cn(roboto.variable, robotoSlab.variable, 'font-sans text-default')}>
+        <body
+          className={cn(
+            roboto.variable,
+            robotoSlab.variable,
+            'overflow-hidden font-sans text-default',
+          )}
+        >
           <DefaultBasemap />
           {children}
         </body>

--- a/client/src/components/network-diagram/item.tsx
+++ b/client/src/components/network-diagram/item.tsx
@@ -13,6 +13,7 @@ import { useIsOverTwoLines } from '@/hooks/ui/utils';
 
 import { CollapsibleTrigger } from '@/components/ui/collapsible';
 import { SlidingLinkButton } from '@/components/ui/sliding-link-button';
+
 import Document from '@/styles/icons/document.svg';
 
 type PathProps = {
@@ -93,7 +94,8 @@ const Item = ({
   };
   const ref = useRef<HTMLDivElement>(null);
   const isOverTwoLines = useIsOverTwoLines(ref, true);
-
+  const canExpandWithChildren = typeof onToggle !== 'undefined' && hasChildren;
+  const canExpandWithoutChildren = typeof onToggle !== 'undefined' && !hasChildren;
   return (
     <div className="relative -mt-6 w-full">
       {/* DOT */}
@@ -114,7 +116,7 @@ const Item = ({
       )}
       {/* CONTENT */}
       <div
-        className={cn('mt-10 flex h-20 w-fit min-w-full items-center justify-between gap-8 p-4', {
+        className={cn('mt-10 flex h-20 w-fit min-w-full items-center justify-between gap-6 p-4', {
           'border border-slate-700': isFirstNode || opened,
           'bg-blue-50': type === 'organization',
           'bg-peach-50': type === 'project',
@@ -130,12 +132,14 @@ const Item = ({
           {name}
         </div>
         {category && (
-          <div className="flex min-w-fit items-center gap-4">
+          <div className="flex min-w-fit max-w-fit items-center gap-4">
             <SlidingLinkButton
               isCompact
               buttonClassName={cn('p-0 m-0', {
                 'bg-blue-100': type === 'organization',
                 'bg-peach-100': type === 'project',
+                // Compensate for the missing button
+                'mr-10': canExpandWithoutChildren,
               })}
               href={`/network/${type}/${id}?${searchParams.toString()}`}
               position="right"
@@ -143,7 +147,7 @@ const Item = ({
             >
               Learn more
             </SlidingLinkButton>
-            {typeof onToggle !== 'undefined' && hasChildren && (
+            {canExpandWithChildren && (
               <CollapsibleTrigger onClick={toggleOpenCollapsible}>
                 <ChevronDown
                   className={cn('transform transition-transform', {


### PR DESCRIPTION
On the network diagram
- Add space for intermediate networks if the expanding is not available
- Fix cut arrows on narrow screens and irregular distribution on items
- Remove extra padding that was not on the designs
- Prevent overflow on short screens