### PR TITLE
Add a link to Scientific Evidence's temporal environment

### DIFF
--- a/client/src/constants/modules.ts
+++ b/client/src/constants/modules.ts
@@ -35,7 +35,8 @@ export const modules = [
   },
   {
     name: 'Scientific Evidence',
-    href: '/scientific-evidence',
+    // NOTE: temporal URL
+    href: 'http://ns3192284.ip-5-39-73.eu/scientific_evidence/',
     color: 'teal',
   },
   {

--- a/client/src/types/app.ts
+++ b/client/src/types/app.ts
@@ -1,3 +1,5 @@
 import { modules } from '@/constants/modules';
 
-export type Section = (typeof modules)[number]['href'] extends `/${infer slug}` ? slug : never;
+type ExtractSlug<T extends string> = T extends `/${infer slug}` ? slug : never;
+
+export type Section = ExtractSlug<(typeof modules)[number]['href']>;


### PR DESCRIPTION
This PR adds a link to Scientific Evidence's temporal environment.

## Acceptance criteria

- The “Scientific Evidence” button redirects users to the Scientific Evidence application http://ns3192284.ip-5-39-73.eu/scientific_evidence/
- The Scientific Evidence application opens in the same tab

## Tracking

[ORC-291](https://vizzuality.atlassian.net/browse/ORC-291)

[ORC-291]: https://vizzuality.atlassian.net/browse/ORC-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ