### PR TITLE
Add a link to Practices' temporal environment

### DIFF
--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -6,9 +6,10 @@ import { cn } from '@/lib/classnames';
 
 import { Module, moduleColors, modules } from '@/constants/modules';
 
-const LinkBox = ({ href, color, name }: Module) => (
+const LinkBox = ({ href, openNewTab, color, name }: Module) => (
   <Link
     href={href}
+    target={openNewTab ? '_blank' : undefined}
     className={cn(
       'relative flex h-[279px] w-[308px] items-center justify-center',
       moduleColors[color].background,

--- a/client/src/constants/modules.ts
+++ b/client/src/constants/modules.ts
@@ -24,6 +24,7 @@ export const moduleColors = {
 export interface Module {
   name: string;
   href: string;
+  openNewTab?: boolean;
   color: keyof typeof moduleColors;
 }
 
@@ -40,7 +41,9 @@ export const modules = [
   },
   {
     name: 'Practices',
-    href: '/practices',
+    // NOTE: temporal URL
+    href: 'http://orcasa.ekoal.org/',
+    openNewTab: true,
     color: 'brown',
   },
   {

--- a/client/src/containers/nav/index.tsx
+++ b/client/src/containers/nav/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 'use client';
 
-import { PropsWithChildren } from 'react';
+import { HTMLAttributeAnchorTarget, PropsWithChildren } from 'react';
 
 import Image from 'next/image';
 import Link from 'next/link';
@@ -11,9 +11,11 @@ import { cn } from '@/lib/classnames';
 
 import { Module, moduleColors, modules } from '@/constants/modules';
 
-type NavLinkProps = PropsWithChildren<Omit<Module, 'name'> & { active?: boolean }>;
+type NavLinkProps = PropsWithChildren<
+  Omit<Module, 'name'> & { active?: boolean; target?: HTMLAttributeAnchorTarget }
+>;
 
-const NavLink = ({ href, children, color, active }: NavLinkProps) => (
+const NavLink = ({ href, children, color, active, ...rest }: NavLinkProps) => (
   <Link
     className={cn(
       'flex h-[68px] cursor-pointer items-center justify-start border-l-8 py-4 pl-4 pr-4 font-serif text-sm leading-tight transition-colors duration-200 hover:bg-white hover:text-slate-700',
@@ -26,6 +28,7 @@ const NavLink = ({ href, children, color, active }: NavLinkProps) => (
       },
     )}
     href={href}
+    {...rest}
   >
     {children}
   </Link>
@@ -42,9 +45,15 @@ export default function Nav() {
         </Link>
         <div className="flex flex-col gap-px bg-slate-600 py-px">
           {modules.map((module) => {
-            const { href, color, name } = module;
+            const { href, openNewTab, color, name } = module as Module;
             return (
-              <NavLink key={href} href={href} color={color} active={pathname === href}>
+              <NavLink
+                key={href}
+                href={href}
+                target={openNewTab ? '_blank' : undefined}
+                color={color}
+                active={pathname === href}
+              >
                 {name}
               </NavLink>
             );

--- a/client/src/containers/sidebar/index.tsx
+++ b/client/src/containers/sidebar/index.tsx
@@ -61,7 +61,8 @@ export default function Sidebar({
   const widthClassName = useMemo(() => {
     const sectionMaxWidth: Partial<Record<Section, string>> = {
       'geospatial-data': 'w-[min(35%,_490px)]',
-      practices: 'w-[min(45%,_820px)]',
+      // NOTE: add back the next line when the external link is removed
+      // practices: 'w-[min(45%,_820px)]',
       network: 'w-[min(45%,_860px)]',
     };
     return sectionMaxWidth[section] ?? '';

--- a/client/src/types/app.ts
+++ b/client/src/types/app.ts
@@ -1,3 +1,5 @@
 import { modules } from '@/constants/modules';
 
-export type Section = (typeof modules)[number]['href'] extends `/${infer slug}` ? slug : never;
+type ExtractSlug<T extends string> = T extends `/${infer slug}` ? slug : never;
+
+export type Section = ExtractSlug<(typeof modules)[number]['href']>;


### PR DESCRIPTION
This PR adds a link to Practices' temporal environment.

## Acceptance criteria

- The “Datasets” button redirects users to the Datasets application http://orcasa.ekoal.org/
  - 🧑‍💻 Applies only to the Next.js application
- The Datasets application opens in a separate tab

## Tracking

[ORC-290](https://vizzuality.atlassian.net/browse/ORC-290)

[ORC-290]: https://vizzuality.atlassian.net/browse/ORC-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ