### PR TITLE
[Network] Allow the user to reset organisation and project filters

### DIFF
--- a/client/src/app/(modules)/network/filters-sidebar.tsx
+++ b/client/src/app/(modules)/network/filters-sidebar.tsx
@@ -6,7 +6,13 @@ import { X } from 'lucide-react';
 
 import { cn } from '@/lib/classnames';
 
-import { useNetworkFilterSidebarOpen, useNetworkFilters } from '@/store/network';
+import {
+  useFiltersCount,
+  useNetworkFilterSidebarOpen,
+  useNetworkFilters,
+  useNetworkOrganizationFilters,
+  useNetworkProjectFilters,
+} from '@/store/network';
 
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -15,6 +21,10 @@ import { Label } from '@/components/ui/label';
 export default function FiltersSidebar() {
   const [filterSidebarOpen, setFilterSidebarOpen] = useNetworkFilterSidebarOpen();
   const [filters, setFilters] = useNetworkFilters();
+  const [organizationFilters] = useNetworkOrganizationFilters();
+  const [projectFilters] = useNetworkProjectFilters();
+  const organizationFiltersCount = useFiltersCount(organizationFilters);
+  const projectFiltersCount = useFiltersCount(projectFilters);
 
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -48,39 +58,84 @@ export default function FiltersSidebar() {
           <X className="h-6 w-6" />
         </Button>
         <h1 className="font-serif text-3.8xl">Filters</h1>
-        <fieldset className="flex flex-col gap-y-4">
-          <legend className="mb-4 font-semibold">Type</legend>
-          <div className="flex items-center gap-x-2">
-            <Checkbox
-              id="filter-organization"
-              checked={filters.type?.includes('organization') ?? false}
-              onCheckedChange={(checked) =>
+        <div className="flex flex-col gap-y-10">
+          <fieldset className="flex flex-col gap-y-4">
+            <legend className="mb-4 font-semibold">Type</legend>
+            <div className="flex items-center gap-x-2">
+              <Checkbox
+                id="filter-organization"
+                checked={filters.type?.includes('organization') ?? false}
+                onCheckedChange={(checked) =>
+                  setFilters({
+                    ...filters,
+                    type: checked
+                      ? [...(filters.type ?? []), 'organization']
+                      : (filters.type ?? []).filter((filter) => filter !== 'organization'),
+                  })
+                }
+              />
+              <Label htmlFor="filter-organization">Organizations</Label>
+            </div>
+            <div className="flex items-center gap-x-2">
+              <Checkbox
+                id="filter-project"
+                checked={filters.type?.includes('project') ?? false}
+                onCheckedChange={(checked) =>
+                  setFilters({
+                    ...filters,
+                    type: checked
+                      ? [...(filters.type ?? []), 'project']
+                      : (filters.type ?? []).filter((filter) => filter !== 'project'),
+                  })
+                }
+              />
+              <Label htmlFor="filter-project">Projects</Label>
+            </div>
+          </fieldset>
+          <fieldset className="relative">
+            <legend className="mb-4 font-semibold">Organisation</legend>
+            <Button
+              type="button"
+              variant="vanilla"
+              size="auto"
+              className="absolute bottom-full right-0 -translate-y-4 text-base font-semibold text-blue-500 hover:text-blue-800 disabled:text-gray-300 disabled:opacity-100"
+              disabled={organizationFiltersCount === 0}
+              onClick={() =>
                 setFilters({
                   ...filters,
-                  type: checked
-                    ? [...(filters.type ?? []), 'organization']
-                    : (filters.type ?? []).filter((filter) => filter !== 'organization'),
+                  organizationType: null,
+                  mainThematic: null,
+                  country: null,
                 })
               }
-            />
-            <Label htmlFor="filter-organization">Organizations</Label>
-          </div>
-          <div className="flex items-center gap-x-2">
-            <Checkbox
-              id="filter-project"
-              checked={filters.type?.includes('project') ?? false}
-              onCheckedChange={(checked) =>
+            >
+              Reset all
+            </Button>
+          </fieldset>
+          <fieldset className="relative">
+            <legend className="mb-4 font-semibold">Project</legend>
+            <Button
+              type="button"
+              variant="vanilla"
+              size="auto"
+              className="absolute bottom-full right-0 -translate-y-4 text-base font-semibold text-peach-700 hover:text-peach-900 disabled:text-gray-300 disabled:opacity-100"
+              disabled={projectFiltersCount === 0}
+              onClick={() =>
                 setFilters({
                   ...filters,
-                  type: checked
-                    ? [...(filters.type ?? []), 'project']
-                    : (filters.type ?? []).filter((filter) => filter !== 'project'),
+                  projectType: null,
+                  status: null,
+                  coordinationCountry: null,
+                  interventionRegion: null,
+                  interventionCountry: null,
+                  interventionArea: null,
                 })
               }
-            />
-            <Label htmlFor="filter-project">Projects</Label>
-          </div>
-        </fieldset>
+            >
+              Reset all
+            </Button>
+          </fieldset>
+        </div>
       </div>
     </div>
   );

--- a/client/src/app/(modules)/network/page.tsx
+++ b/client/src/app/(modules)/network/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 
 import { Filter, Plus } from 'lucide-react';
 import { usePreviousImmediate } from 'rooks';
 
 import { useSidebarScroll } from '@/store';
 
-import { useNetworkFilterSidebarOpen, useNetworkFilters } from '@/store/network';
+import { useFiltersCount, useNetworkFilterSidebarOpen, useNetworkFilters } from '@/store/network';
 
 import { useNetworks } from '@/hooks/networks';
 
@@ -32,25 +32,8 @@ const AddButton = ({ text }: { text: string }) => (
 export default function NetworkModule() {
   const [filters] = useNetworkFilters();
   const networks = useNetworks({ page: 1, filters });
-
-  const filtersCount = useMemo(
-    () =>
-      Object.keys(filters).filter((key) => {
-        const value = filters[key as keyof typeof filters];
-
-        const isSearchFilter = key === 'search';
-        let hasValue = true;
-        if (Array.isArray(value) || typeof value === 'string') {
-          hasValue = value.length > 0;
-        } else {
-          hasValue = value !== null && value !== undefined;
-        }
-
-        // The keywords search is not counted because it's shown in the main sidebar
-        return !isSearchFilter && hasValue;
-      }).length,
-    [filters],
-  );
+  // The keywords search is not counted because it's shown in the main sidebar
+  const filtersCount = useFiltersCount(filters, ['search']);
 
   const [filterSidebarOpen, setFilterSidebarOpen] = useNetworkFilterSidebarOpen();
   const previousFilterSidebarOpen = usePreviousImmediate(filterSidebarOpen);

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -35,7 +35,7 @@ const buttonVariants = cva(
         sm: 'h-9 rounded-md px-3',
         lg: 'h-11 rounded-md px-8',
         icon: 'h-10 w-10',
-        asChild: '',
+        auto: '',
       },
     },
     defaultVariants: {

--- a/client/src/containers/layer-groups-list/layers/layer.tsx
+++ b/client/src/containers/layer-groups-list/layers/layer.tsx
@@ -93,7 +93,7 @@ export default function Layer({ id, attributes }: LayerGroupLayersDataItem) {
         <div className="flex items-center gap-4 pt-1">
           <Dialog>
             <DialogTrigger asChild>
-              <Button variant="vanilla" size="asChild" className={cn({ 'text-white': isActive })}>
+              <Button variant="vanilla" size="auto" className={cn({ 'text-white': isActive })}>
                 <span className="sr-only">Info button</span>
                 <Info className="h-6 w-6" />
               </Button>

--- a/client/src/store/network.ts
+++ b/client/src/store/network.ts
@@ -1,9 +1,45 @@
+import { useCallback, useMemo } from 'react';
+
 import { atom, useAtom } from 'jotai';
 
-export interface NetworkFilters {
+export interface NetworkGeneralFilters {
   type?: string[];
-  // search?: string;
+  search?: string;
 }
+
+export interface NetworkOrganizationFilters {
+  organizationType?: unknown;
+  mainThematic?: unknown;
+  country?: unknown;
+}
+
+export interface NetworkProjectFilters {
+  projectType?: unknown;
+  status?: unknown;
+  coordinationCountry?: unknown;
+  interventionRegion?: unknown;
+  interventionCountry?: unknown;
+  interventionArea?: unknown;
+}
+
+export type NetworkFilters = NetworkGeneralFilters &
+  NetworkOrganizationFilters &
+  NetworkProjectFilters;
+
+const organizationFiltersKeys: (keyof NetworkOrganizationFilters)[] = [
+  'organizationType',
+  'mainThematic',
+  'country',
+];
+
+const projectFiltersKeys: (keyof NetworkProjectFilters)[] = [
+  'projectType',
+  'status',
+  'coordinationCountry',
+  'interventionRegion',
+  'interventionCountry',
+  'interventionArea',
+];
 
 const filterSidebarOpenAtom = atom(false);
 export const useNetworkFilterSidebarOpen = () => {
@@ -13,4 +49,74 @@ export const useNetworkFilterSidebarOpen = () => {
 const filtersAtom = atom<NetworkFilters>({ type: [] });
 export const useNetworkFilters = () => {
   return useAtom(filtersAtom);
+};
+
+export const useNetworkOrganizationFilters = () => {
+  const [filters, setFilters] = useNetworkFilters();
+
+  const organizationFilters: NetworkOrganizationFilters = useMemo(
+    () =>
+      Object.entries(filters)
+        .filter(([key]) =>
+          organizationFiltersKeys.includes(key as keyof NetworkOrganizationFilters),
+        )
+        .reduce((res, [key, value]) => ({ ...res, [key]: value }), {}),
+    [filters],
+  );
+
+  const setOrganizationFilters = useCallback(
+    (organizationFilters: NetworkOrganizationFilters) =>
+      setFilters((filters) => ({
+        ...filters,
+        ...organizationFilters,
+      })),
+    [setFilters],
+  );
+
+  return [organizationFilters, setOrganizationFilters] as const;
+};
+
+export const useNetworkProjectFilters = () => {
+  const [filters, setFilters] = useNetworkFilters();
+
+  const projectFilters: NetworkProjectFilters = useMemo(
+    () =>
+      Object.entries(filters)
+        .filter(([key]) => projectFiltersKeys.includes(key as keyof NetworkProjectFilters))
+        .reduce((res, [key, value]) => ({ ...res, [key]: value }), {}),
+    [filters],
+  );
+
+  const setProjectFilters = useCallback(
+    (projectFilters: NetworkProjectFilters) =>
+      setFilters((filters) => ({
+        ...filters,
+        ...projectFilters,
+      })),
+    [setFilters],
+  );
+
+  return [projectFilters, setProjectFilters] as const;
+};
+
+export const useFiltersCount = (
+  filters: NetworkFilters,
+  ignoreFiltersKeys: (keyof NetworkFilters)[] = [],
+) => {
+  return Object.keys(filters).filter((key) => {
+    if (ignoreFiltersKeys.includes(key as keyof NetworkFilters)) {
+      return false;
+    }
+
+    const value = filters[key as keyof NetworkFilters];
+
+    let hasValue = true;
+    if (Array.isArray(value) || typeof value === 'string') {
+      hasValue = value.length > 0;
+    } else {
+      hasValue = value !== null && value !== undefined;
+    }
+
+    return hasValue;
+  }).length;
 };

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -60,6 +60,7 @@ module.exports = {
           100: '#FFECDB',
           // Projects
           700: '#EF6A4C',
+          900: '#CA3412',
         },
         brown: {
           // Practices


### PR DESCRIPTION
On the Network module, this PR adds the code that allows the user to reset the organisation and project filters. These filters are not implemented yet.

## Acceptance criteria

- There is a way to reset filters:
  - There is a way to reset all the organisation filters (and filter options)
  - There is a way to reset all the project filters (and filter options)

## Tracking

[ORC-245](https://vizzuality.atlassian.net/browse/ORC-245)

[ORC-245]: https://vizzuality.atlassian.net/browse/ORC-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ