### PR TITLE
[Network] Allow the user to search the list and map by keywords

### DIFF
--- a/client/src/app/(modules)/network/network-list.tsx
+++ b/client/src/app/(modules)/network/network-list.tsx
@@ -26,6 +26,11 @@ export default function NetworkList({
       isPlaceholderData={isPlaceholderData}
       isError={isError}
     >
+      {!networks?.length && (
+        <p className="py-8 text-center font-semibold text-slate-500">
+          No results based on your search criteria
+        </p>
+      )}
       {networks?.map((g) => {
         return (
           <Network

--- a/client/src/app/(modules)/network/page.tsx
+++ b/client/src/app/(modules)/network/page.tsx
@@ -30,7 +30,7 @@ const AddButton = ({ text }: { text: string }) => (
 );
 
 export default function NetworkModule() {
-  const [filters] = useNetworkFilters();
+  const [filters, setFilters] = useNetworkFilters();
   const networks = useNetworks({ page: 1, filters });
   // The keywords search is not counted because it's shown in the main sidebar
   const filtersCount = useFiltersCount(filters, ['search']);
@@ -73,9 +73,8 @@ export default function NetworkModule() {
       <div className="flex justify-between gap-x-4">
         <Search
           containerClassName="basis-full"
-          onChange={() => {
-            // TODO - search
-          }}
+          defaultValue={filters.search}
+          onChange={(keywords) => setFilters({ ...filters, search: keywords })}
         />
         <Button
           ref={filtersButtonRef}

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -11,10 +11,10 @@ const buttonVariants = cva(
     variants: {
       variant: {
         // From the UI kit
+        default: 'bg-gray-100 hover:bg-gray-200',
         primary: 'bg-gray-700 hover:bg-gray-800 text-white',
         vanilla: '',
         // Not reviewed yet
-        default: 'border border-blue-500 px-4 py-2 hover:bg-gray-50 text-sky-700',
         destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-gray-50',

--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -4,13 +4,12 @@ import { cn } from '@/lib/classnames';
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   icon?: React.ReactNode;
-  containerClassName?: string;
 };
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, icon, containerClassName, ...props }, ref) => {
+  ({ className, type, icon, ...props }, ref) => {
     return (
-      <div className={cn('relative', containerClassName)}>
+      <div className="relative">
         <div className="absolute left-4 top-4">{icon}</div>
         <input
           type={type}

--- a/client/src/components/ui/search.tsx
+++ b/client/src/components/ui/search.tsx
@@ -3,12 +3,13 @@ import { useDebounce } from 'rooks';
 
 import { Input } from '@/components/ui/input';
 type SearchProps = {
+  defaultValue?: string;
   className?: string;
   containerClassName?: string;
   onChange: (newValue: string) => void;
 };
 
-const Search = ({ className, containerClassName, onChange }: SearchProps) => {
+const Search = ({ defaultValue, className, containerClassName, onChange }: SearchProps) => {
   const debouncedOnChange = useDebounce((newValue: string) => {
     onChange(newValue);
   }, 250);
@@ -25,6 +26,7 @@ const Search = ({ className, containerClassName, onChange }: SearchProps) => {
       aria-label="Search by keyword"
       placeholder="Search by keyword"
       icon={<SearchIcon />}
+      defaultValue={defaultValue}
       onChange={handleInputChange}
     />
   );

--- a/client/src/components/ui/search.tsx
+++ b/client/src/components/ui/search.tsx
@@ -1,7 +1,13 @@
+import { useCallback, useRef, useState } from 'react';
+
 import { Search as SearchIcon } from 'lucide-react';
 import { useDebounce } from 'rooks';
 
+import { cn } from '@/lib/classnames';
+
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import Cross from '@/styles/icons/cross.svg';
 type SearchProps = {
   defaultValue?: string;
   className?: string;
@@ -9,26 +15,54 @@ type SearchProps = {
   onChange: (newValue: string) => void;
 };
 
-const Search = ({ defaultValue, className, containerClassName, onChange }: SearchProps) => {
+const Search = ({ defaultValue = '', className, containerClassName, onChange }: SearchProps) => {
+  const [value, setValue] = useState(defaultValue);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
   const debouncedOnChange = useDebounce((newValue: string) => {
     onChange(newValue);
   }, 250);
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    debouncedOnChange(event.target.value);
-  };
+  const onChangeInput = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+
+      setValue(value);
+      debouncedOnChange(value);
+    },
+    [setValue, debouncedOnChange],
+  );
+
+  const onClearInput = useCallback(() => {
+    setValue('');
+    debouncedOnChange('');
+    inputRef.current?.focus();
+  }, [setValue, debouncedOnChange, inputRef]);
 
   return (
-    <Input
-      className={className}
-      containerClassName={containerClassName}
-      type="text"
-      aria-label="Search by keyword"
-      placeholder="Search by keyword"
-      icon={<SearchIcon />}
-      defaultValue={defaultValue}
-      onChange={handleInputChange}
-    />
+    <div className={cn('relative', containerClassName)}>
+      <Input
+        ref={inputRef}
+        className={cn('pr-14 search-cancel:hidden', className)}
+        type="search"
+        aria-label="Search by keyword"
+        placeholder="Search by keyword"
+        icon={<SearchIcon />}
+        value={value}
+        onChange={onChangeInput}
+      />
+      {value.length > 0 && (
+        <Button
+          type="button"
+          size="icon-sm"
+          className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full"
+          onClick={onClearInput}
+        >
+          <span className="sr-only">Clear search</span>
+          <Cross className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
   );
 };
 

--- a/client/src/hooks/networks/index.ts
+++ b/client/src/hooks/networks/index.ts
@@ -76,6 +76,32 @@ export type NetworkResponse = {
   isError: boolean;
 };
 
+const getQueryFilters = (filters: NetworkFilters) => {
+  return {
+    ...(typeof filters.search !== 'undefined' && filters.search.length > 0
+      ? {
+          $or: [
+            {
+              name: {
+                $containsi: filters.search,
+              },
+            },
+            {
+              short_description: {
+                $containsi: filters.search,
+              },
+            },
+            {
+              description: {
+                $containsi: filters.search,
+              },
+            },
+          ],
+        }
+      : {}),
+  };
+};
+
 const useGetNetworksRelations = ({ id, type }: Network) => {
   const useFunction = type === 'organization' ? useGetOrganizationsId : useGetProjectsId;
   const populate = getPopulateForFilters(type);
@@ -176,6 +202,8 @@ const useGetNetworks = (filters: NetworkFilters) => {
   const loadOrganizations = !filters.type?.length || filters.type.includes('organization');
   const loadProjects = !filters.type?.length || filters.type.includes('project');
 
+  const queryFilters = getQueryFilters(filters);
+
   const {
     data: organizationsData,
     isFetching: organizationIsFetching,
@@ -186,6 +214,7 @@ const useGetNetworks = (filters: NetworkFilters) => {
     {
       populate: 'country',
       'pagination[pageSize]': 9999,
+      filters: queryFilters,
     },
     {
       query: {
@@ -206,6 +235,7 @@ const useGetNetworks = (filters: NetworkFilters) => {
     {
       populate: 'country_of_coordination',
       'pagination[pageSize]': 9999,
+      filters: queryFilters,
     },
     {
       query: {
@@ -373,29 +403,7 @@ export const useNetworks = ({
   const loadOrganizations = !filters.type?.length || filters.type.includes('organization');
   const loadProjects = !filters.type?.length || filters.type.includes('project');
 
-  const queryFilters = {
-    ...(typeof filters.search !== 'undefined' && filters.search.length > 0
-      ? {
-          $or: [
-            {
-              name: {
-                $containsi: filters.search,
-              },
-            },
-            {
-              short_description: {
-                $containsi: filters.search,
-              },
-            },
-            {
-              description: {
-                $containsi: filters.search,
-              },
-            },
-          ],
-        }
-      : {}),
-  };
+  const queryFilters = getQueryFilters(filters);
 
   const {
     data: organizationsData,

--- a/client/src/hooks/networks/index.ts
+++ b/client/src/hooks/networks/index.ts
@@ -373,6 +373,30 @@ export const useNetworks = ({
   const loadOrganizations = !filters.type?.length || filters.type.includes('organization');
   const loadProjects = !filters.type?.length || filters.type.includes('project');
 
+  const queryFilters = {
+    ...(typeof filters.search !== 'undefined' && filters.search.length > 0
+      ? {
+          $or: [
+            {
+              name: {
+                $containsi: filters.search,
+              },
+            },
+            {
+              short_description: {
+                $containsi: filters.search,
+              },
+            },
+            {
+              description: {
+                $containsi: filters.search,
+              },
+            },
+          ],
+        }
+      : {}),
+  };
+
   const {
     data: organizationsData,
     isFetching: organizationIsFetching,
@@ -386,6 +410,7 @@ export const useNetworks = ({
       // TODO: This is a hack to get all organizations for demo purposes. Remember to put it back to 5.
       'pagination[pageSize]': 1000,
       sort: 'name:asc',
+      filters: queryFilters,
     },
     {
       query: {
@@ -409,6 +434,7 @@ export const useNetworks = ({
       // TODO: This is a hack to get all organizations for demo purposes. Remember to put it back to 5.
       'pagination[pageSize]': 1000,
       sort: 'name:asc',
+      filters: queryFilters,
     },
     {
       query: {

--- a/client/src/styles/icons/cross.svg
+++ b/client/src/styles/icons/cross.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 4L4 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 4L12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 
 import defaultTheme from 'tailwindcss/defaultTheme';
+import plugin from 'tailwindcss/plugin';
 
 module.exports = {
   darkMode: ['class'],
@@ -47,6 +48,7 @@ module.exports = {
         },
         gray: {
           50: '#F7F7F9',
+          100: '#F0F0F5',
           200: '#CFD1DB',
           // Disabled for buttons / labels
           300: '#B2B5C5',
@@ -135,5 +137,11 @@ module.exports = {
       },
     },
   },
-  plugins: [require('tailwindcss-animate'), require('@tailwindcss/typography')],
+  plugins: [
+    require('tailwindcss-animate'),
+    require('@tailwindcss/typography'),
+    plugin(({ addVariant }) => {
+      addVariant('search-cancel', '&::-webkit-search-cancel-button');
+    }),
+  ],
 };


### PR DESCRIPTION
On the Network module, this PR adds the possibility to perform a keyword search that filters the list and the map.

## Acceptance criteria

- There is a way to search projects and organizations by keyword
  - Affects both the list and the map
  - Organisations and projects
    - Match names which include the keywords (exact same characters but case insensitive)
    - Match short descriptions which include the keywords (exact same characters but case insensitive)
    - Match descriptions which include the keywords (exact same characters but case insensitive)
- There is a way to clear the search

## Tracking

[ORC-244](https://vizzuality.atlassian.net/browse/ORC-244)

[ORC-244]: https://vizzuality.atlassian.net/browse/ORC-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ