### PR TITLE
Invalidate the homepage's cached statistic data every 10 minutes

### DIFF
--- a/client/src/app/(modules)/network/network.tsx
+++ b/client/src/app/(modules)/network/network.tsx
@@ -16,7 +16,6 @@ import {
 
 import { SlidingLinkButton } from '@/components/ui/sliding-link-button';
 import { WithEllipsis } from '@/components/ui/with-ellipsis';
-
 import CalendarIcon from '@/styles/icons/calendar.svg';
 import FolderIcon from '@/styles/icons/folder.svg';
 import GlobeIcon from '@/styles/icons/globe.svg';

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -3,3 +3,10 @@ import Home from '@/components/home';
 export default async function HomePage() {
   return <Home />;
 }
+
+// By default Next.js caches data fetches on server-side components indefinitely. There is a way to
+// configure the behaviour with options passed to the Fetch API but since we're using Axios, the
+// only way is to set this value on the homepage.
+// What it means is that Next.js should not cache requests made in server-side components more than
+// 10 minutes.
+export const revalidate = 600;

--- a/client/src/components/home/hero-section.tsx
+++ b/client/src/components/home/hero-section.tsx
@@ -7,7 +7,6 @@ import { ArrowRight } from 'lucide-react';
 import Stats from '@/components/home/stats';
 import { Button } from '@/components/ui/button';
 import SmoothScrollLink from '@/components/ui/smooth-scroll-link';
-
 import ArrowDownLong from '@/styles/icons/arrow-down-long.svg';
 
 const HeroSection = () => {

--- a/client/src/components/map/legend/item/toolbar/index.tsx
+++ b/client/src/components/map/legend/item/toolbar/index.tsx
@@ -15,10 +15,9 @@ import {
   TooltipPortal,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import Opacity from '@/styles/icons/opacity.svg';
 
 import Slider from './slider';
-
-import Opacity from '@/styles/icons/opacity.svg';
 
 export const LegendItemToolbar: React.FC<LegendItemToolbarProps> = ({
   settings,

--- a/client/src/components/network-diagram/item.tsx
+++ b/client/src/components/network-diagram/item.tsx
@@ -13,7 +13,6 @@ import { useIsOverTwoLines } from '@/hooks/ui/utils';
 
 import { CollapsibleTrigger } from '@/components/ui/collapsible';
 import { SlidingLinkButton } from '@/components/ui/sliding-link-button';
-
 import Document from '@/styles/icons/document.svg';
 
 type PathProps = {

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -48,7 +48,7 @@ const buttonVariants = cva(
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-  VariantProps<typeof buttonVariants> {
+    VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 

--- a/client/src/containers/nav/index.tsx
+++ b/client/src/containers/nav/index.tsx
@@ -18,7 +18,7 @@ type NavLinkProps = PropsWithChildren<
 const NavLink = ({ href, children, color, active, ...rest }: NavLinkProps) => (
   <Link
     className={cn(
-      'duration-200 flex h-[68px] cursor-pointer items-center justify-start border-l-8 py-4 pl-4 pr-4 font-serif text-sm leading-tight transition-colors hover:bg-white hover:text-slate-700',
+      'flex h-[68px] cursor-pointer items-center justify-start border-l-8 py-4 pl-4 pr-4 font-serif text-sm leading-tight transition-colors duration-200 hover:bg-white hover:text-slate-700',
       moduleColors[color].border,
       {
         'bg-white': active,


### PR DESCRIPTION
This PR fixes an issue where the homepage's statistics are fetched at build time only and never updated when the values are updated on Strapi. With these changes, the data is invalidated every 10 minutes.

## Tracking

[ORC-316](https://vizzuality.atlassian.net/browse/ORC-316)

[ORC-316]: https://vizzuality.atlassian.net/browse/ORC-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ