### PR TITLE
[Geospatial Data] Allow the user to interact with the Tree Cover Loss layer

### DIFF
--- a/client/src/components/home/hero-section.tsx
+++ b/client/src/components/home/hero-section.tsx
@@ -7,7 +7,6 @@ import { ArrowRight } from 'lucide-react';
 import Stats from '@/components/home/stats';
 import { Button } from '@/components/ui/button';
 import SmoothScrollLink from '@/components/ui/smooth-scroll-link';
-
 import ArrowDownLong from '@/styles/icons/arrow-down-long.svg';
 
 const HeroSection = () => {

--- a/client/src/containers/layer-groups-list/layers/index.tsx
+++ b/client/src/containers/layer-groups-list/layers/index.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import dynamic from 'next/dynamic';
+
 import type {
   LayerGroupLayers,
   LayerGroupLayersDataItemAttributes,
 } from '@/types/generated/strapi.schemas';
 
-import Layer from './layer';
+const Layer = dynamic(() => import('./layer'), {
+  ssr: false,
+});
 
 export default function Layers({
   data,

--- a/client/src/containers/layer-groups-list/layers/layer.tsx
+++ b/client/src/containers/layer-groups-list/layers/layer.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { ReactElement, cloneElement, useCallback, useMemo } from 'react';
+
 import { Info } from 'lucide-react';
 
 import { cn } from '@/lib/classnames';
+import { parseConfig } from '@/lib/json-converter';
 
-import { useLayers } from '@/store';
+import { useLayers, useLayersSettings } from '@/store';
 
 import { LayerGroupLayersDataItem } from '@/types/generated/strapi.schemas';
 
@@ -12,12 +15,60 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogTrigger, DialogContent } from '@/components/ui/dialog';
 import { Switch } from '@/components/ui/switch';
 
-export default function Layer({ id, attributes }: LayerGroupLayersDataItem) {
+interface Field {
+  key: string;
+  value: string;
+  url?: string;
+}
+
+const renderField = ({ key, value, url }: Field) => {
+  if (!key || !value) return null;
+  return (
+    <div key={key} className="flex gap-10 text-sm">
+      <div className="w-[134px] min-w-[134px] font-semibold">{key}</div>
+      {url ? (
+        <a
+          href={url}
+          target="_blank"
+          rel="noreferrer"
+          className="font-semibold text-yellow-600 hover:underline"
+        >
+          {value}
+        </a>
+      ) : (
+        <div className="whitespace-pre-wrap">{value}</div>
+      )}
+    </div>
+  );
+};
+
+export default function Layer({ id, attributes = {} }: LayerGroupLayersDataItem) {
   const [layers, setLayers] = useLayers();
+  const [layersSettings, setLayersSettings] = useLayersSettings();
 
-  if (!id) return null;
+  const fields: Field[] = useMemo(
+    () =>
+      [
+        { key: 'License', value: attributes.license ?? '' },
+        { key: 'Citation', value: attributes.citation ?? '' },
+        { key: 'Cautions', value: attributes.cautions ?? '' },
+        { key: 'Related publications', value: attributes.related_publications ?? '' },
+        {
+          key: 'Resource Contact',
+          value: attributes.resource_contact_name ?? '',
+          url: attributes.resource_contact_url,
+        },
+        {
+          key: 'Metadata Contact',
+          value: attributes.metadata_contact_name ?? '',
+          url: attributes.metadata_contact_url,
+        },
+        { key: 'Source', value: attributes.source ?? '', url: attributes.source_url },
+      ].filter((f) => f.value !== ''),
+    [attributes],
+  );
 
-  const handleLayerChange = () => {
+  const handleLayerChange = useCallback(() => {
     if (!id) return;
     // Toogle layers if they exist
     if (layers.includes(id)) {
@@ -28,59 +79,42 @@ export default function Layer({ id, attributes }: LayerGroupLayersDataItem) {
     if (!layers.includes(id)) {
       return setLayers([id, ...layers]);
     }
-  };
+  }, [id, layers, setLayers]);
 
-  const {
-    title,
-    description,
-    license,
-    citation,
-    cautions,
-    related_publications,
-    resource_contact_name,
-    resource_contact_url,
-    metadata_contact_name,
-    metadata_contact_url,
-    source,
-    source_url,
-  } = attributes || {};
+  const layerSettings = useMemo(() => {
+    if (!id || !attributes.ui_settings) {
+      return null;
+    }
 
-  interface Field {
-    key: string;
-    value: string;
-    url?: string;
+    const component = parseConfig<ReactElement | null>({
+      config: attributes.ui_settings,
+      params_config: attributes.params_config,
+      settings: layersSettings[id] ?? { opacity: 1, visibility: true },
+    });
+
+    if (component) {
+      return cloneElement(component, {
+        paramsConfig: attributes.params_config,
+        onChangeSettings: (settings: Record<string, unknown>) =>
+          setLayersSettings((previousSettings) => ({
+            ...previousSettings,
+            [id]: {
+              ...(previousSettings[id] ?? {}),
+              ...settings,
+            },
+          })),
+      });
+    }
+
+    return component;
+  }, [attributes, id, layersSettings, setLayersSettings]);
+
+  if (!id) {
+    return null;
   }
 
-  const fields: Field[] = [
-    { key: 'License', value: license || '' },
-    { key: 'Citation', value: citation || '' },
-    { key: 'Cautions', value: cautions || '' },
-    { key: 'Related publications', value: related_publications || '' },
-    { key: 'Resource Contact', value: resource_contact_name || '', url: resource_contact_url },
-    { key: 'Metadata Contact', value: metadata_contact_name || '', url: metadata_contact_url },
-    { key: 'Source', value: source || '', url: source_url },
-  ].filter((f) => f.value !== '');
-  const renderField = ({ key, value, url }: Field) => {
-    if (!key || !value) return null;
-    return (
-      <div key={key} className="flex gap-10 text-sm">
-        <div className="w-[134px] min-w-[134px] font-semibold">{key}</div>
-        {url ? (
-          <a
-            href={url}
-            target="_blank"
-            rel="noreferrer"
-            className="font-semibold text-yellow-600 hover:underline"
-          >
-            {value}
-          </a>
-        ) : (
-          <div className="whitespace-pre-wrap">{value}</div>
-        )}
-      </div>
-    );
-  };
   const isActive = layers.includes(id);
+
   return (
     <li
       key={id}
@@ -89,7 +123,7 @@ export default function Layer({ id, attributes }: LayerGroupLayersDataItem) {
       })}
     >
       <header className="flex items-start justify-between gap-x-4">
-        <h4 className="font-serif text-lg leading-7">{title}</h4>
+        <h4 className="font-serif text-lg leading-7">{attributes.title}</h4>
         <div className="flex items-center gap-4 pt-1">
           <Dialog>
             <DialogTrigger asChild>
@@ -99,8 +133,8 @@ export default function Layer({ id, attributes }: LayerGroupLayersDataItem) {
               </Button>
             </DialogTrigger>
             <DialogContent onCloseAutoFocus={(e) => e.preventDefault()}>
-              <div className="font-serif text-2xl leading-10">{title}</div>
-              <div className="whitespace-pre-wrap text-sm">{description}</div>
+              <div className="font-serif text-2xl leading-10">{attributes.title}</div>
+              <div className="whitespace-pre-wrap text-sm">{attributes.description}</div>
               {fields.map(renderField)}
             </DialogContent>
           </Dialog>
@@ -111,9 +145,10 @@ export default function Layer({ id, attributes }: LayerGroupLayersDataItem) {
           />
         </div>
       </header>
+      {isActive && layerSettings}
       <div className="flex justify-end">
         <a
-          href={source_url}
+          href={attributes.source_url}
           target="_blank"
           rel="noreferrer"
           className={cn({
@@ -122,7 +157,7 @@ export default function Layer({ id, attributes }: LayerGroupLayersDataItem) {
             'text-white': isActive,
           })}
         >
-          {source}
+          {attributes.source}
         </a>
       </div>
     </li>

--- a/client/src/containers/layer-groups-list/settings/tree-cover-loss.tsx
+++ b/client/src/containers/layer-groups-list/settings/tree-cover-loss.tsx
@@ -1,0 +1,101 @@
+import { useMemo } from 'react';
+
+import { ParamsConfig } from '@/types/layers';
+
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from '@/components/ui/select';
+export interface TreeCoverLossSettings {
+  description: string;
+  startYear: number;
+  endYear: number;
+  paramsConfig: ParamsConfig;
+  onChangeSettings: (settings: Record<string, unknown>) => unknown;
+}
+
+const TreeCoverLossSettings: React.FC<TreeCoverLossSettings> = ({
+  description,
+  startYear: startYearValue,
+  endYear: endYearValue,
+  paramsConfig,
+  onChangeSettings,
+}) => {
+  const startYear = useMemo(
+    () => paramsConfig.find(({ key }) => key === 'startYear')?.default as number,
+    [paramsConfig],
+  );
+
+  const endYear = useMemo(
+    () => paramsConfig.find(({ key }) => key === 'endYear')?.default as number,
+    [paramsConfig],
+  );
+
+  const options = useMemo(
+    () =>
+      startYear && endYear
+        ? Array.from({
+            length: endYear - startYear + 1,
+          }).map((_, index) => ({
+            label: startYear + index,
+            value: startYear + index,
+          }))
+        : [],
+    [startYear, endYear],
+  );
+
+  return (
+    <>
+      <p>{description}</p>
+      <div className="flex items-center gap-x-4">
+        <label htmlFor="tree-cover-loss-from">From</label>
+        <Select
+          value={`${startYearValue}`}
+          onValueChange={(value) => onChangeSettings({ startYear: +value })}
+        >
+          <SelectTrigger id="tree-cover-loss-from" className="h-12 w-auto">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map(({ label, value }) => (
+              <SelectItem
+                key={value}
+                value={`${value}`}
+                disabled={value > endYearValue}
+                className="w-full"
+              >
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <label htmlFor="tree-cover-loss-to">to</label>
+        <Select
+          value={`${endYearValue}`}
+          onValueChange={(value) => onChangeSettings({ endYear: +value })}
+        >
+          <SelectTrigger id="tree-cover-loss-to" className="h-12 w-auto">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map(({ label, value }) => (
+              <SelectItem
+                key={value}
+                value={`${value}`}
+                disabled={value < startYearValue}
+                className="w-full"
+              >
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </>
+  );
+};
+
+export default TreeCoverLossSettings;

--- a/client/src/lib/json-converter/index.ts
+++ b/client/src/lib/json-converter/index.ts
@@ -7,6 +7,8 @@ import FUNCTIONS from '@/lib/utils';
 
 import { ParamsConfig } from '@/types/layers';
 
+import TreeCoverLossSettings from '@/containers/layer-groups-list/settings/tree-cover-loss';
+
 import DecodeLayer from '@/components/map/layers/decode-layer';
 import {
   LegendTypeBasic,
@@ -16,19 +18,14 @@ import {
 
 export const JSON_CONFIGURATION = new JSONConfiguration({
   React,
-  classes: Object.assign(
-    //
-    {},
-    require('@deck.gl/layers'),
-    require('@deck.gl/aggregation-layers'),
-    { DecodeLayer },
-  ),
+  classes: Object.assign({}, { DecodeLayer }),
   functions: FUNCTIONS,
   enumerations: {},
   reactComponents: {
     LegendTypeBasic,
     LegendTypeChoropleth,
     LegendTypeGradient,
+    TreeCoverLossSettings,
   },
 });
 

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -37,7 +37,9 @@ export const useLayers = () => {
 export const useLayersSettings = () => {
   return useQueryState(
     'layers-settings',
-    parseAsJson<Record<string, { opacity?: number; visibility?: boolean }>>().withDefault({}),
+    parseAsJson<
+      Record<string, { opacity?: number; visibility?: boolean; [key: string]: unknown }>
+    >().withDefault({}),
   );
 };
 

--- a/client/src/types/generated/strapi.schemas.ts
+++ b/client/src/types/generated/strapi.schemas.ts
@@ -5404,6 +5404,7 @@ export type PageLayerGroupsDataItemAttributesLayersDataItemAttributes = {
   metadata_contact_name?: string;
   metadata_contact_url?: string;
   highlighted_bounds?: unknown;
+  ui_settings?: unknown;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -7350,6 +7351,7 @@ export type LayerGroupLayersDataItemAttributes = {
   metadata_contact_name?: string;
   metadata_contact_url?: string;
   highlighted_bounds?: unknown;
+  ui_settings?: unknown;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -7634,6 +7636,7 @@ export interface Layer {
   metadata_contact_name?: string;
   metadata_contact_url?: string;
   highlighted_bounds?: unknown;
+  ui_settings?: unknown;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -7870,6 +7873,7 @@ export type LayerRequestData = {
   metadata_contact_name?: string;
   metadata_contact_url?: string;
   highlighted_bounds?: unknown;
+  ui_settings?: unknown;
 };
 
 export interface LayerRequest {

--- a/client/src/types/layers.ts
+++ b/client/src/types/layers.ts
@@ -19,7 +19,7 @@ export type ParamsConfigValue = {
   default: unknown;
 };
 
-export type ParamsConfig = Record<string, ParamsConfigValue>[];
+export type ParamsConfig = ParamsConfigValue[];
 
 export type LegendConfig = {
   type: 'basic' | 'gradient' | 'choropleth';

--- a/cms/src/api/layer/content-types/layer/schema.json
+++ b/cms/src/api/layer/content-types/layer/schema.json
@@ -75,6 +75,9 @@
     },
     "highlighted_bounds": {
       "type": "json"
+    },
+    "ui_settings": {
+      "type": "json"
     }
   }
 }

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -859,6 +859,7 @@ export interface ApiLayerLayer extends Schema.CollectionType {
     metadata_contact_name: Attribute.String;
     metadata_contact_url: Attribute.String;
     highlighted_bounds: Attribute.JSON;
+    ui_settings: Attribute.JSON;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
This PR allows the user to interact with the Tree Cover Loss layer i.e. changing the start and end years.

In order to let the user change the start and end years, I've created a new attribute in the `Layer` model called `ui_settings`.

## How to test

On your local instance of Strapi, create a new layer as follows (don't forget to assign it to a layer group!):

- **type**: deckgl
- **config**:

```json
{
  "@@type": "DecodeLayer",
  "source": {
    "type": "raster",
    "tiles": [
      "https://tiles.globalforestwatch.org/umd_tree_cover_loss/v1.10/tcd_30/{z}/{x}/{y}.png"
    ],
    "maxzoom": 12,
    "minzoom": 2
  },
  "styles": [
    {
      "id": "tree-cover-loss",
      "type": "raster",
      "paint": {
        "raster-opacity": {
          "o": "@@#params.opacity",
          "@@function": "setOpacity"
        }
      },
      "layout": {
        "visibility": {
          "v": "@@#params.visibility",
          "type": "deckgl",
          "@@function": "setVisibility"
        }
      }
    }
  ],
  "decodeParams": {
    "endYear": "@@#params.endYear",
    "startYear": "@@#params.startYear"
  },
  "decodeFunction": "// values for creating power scale, domain (input), and range (output)\nfloat domainMin = 0.;\nfloat domainMax = 255.;\nfloat rangeMin = 0.;\nfloat rangeMax = 255.;\nfloat exponent = zoom < 13. ? 0.3 + (zoom - 3.) / 20. : 1.;\nfloat intensity = color.r * 255.;\n// get the min, max, and current values on the power scale\nfloat minPow = pow(domainMin, exponent - domainMin);\nfloat maxPow = pow(domainMax, exponent);\nfloat currentPow = pow(intensity, exponent);\n// get intensity value mapped to range\nfloat scaleIntensity = ((currentPow - minPow) / (maxPow - minPow) * (rangeMax - rangeMin)) + rangeMin;\n// a value between 0 and 255\ncolor.a *= zoom < 13. ? scaleIntensity / 255. : color.g;\nfloat year = 2000.0 + (color.b * 255.);\n// map to years\nif (year >= startYear && year <= endYear && year >= 2001.) {\n  color.r = 220. / 255.;\n  color.g = (72. - zoom + 102. - 3. * scaleIntensity / zoom) / 255.;\n  color.b = (33. - zoom + 153. - intensity / zoom) / 255.;\n} else {\n  color.a = 0.;\n}"
}
```

- `params_config`:

```json
[
  {
    "key": "opacity",
    "default": 1
  },
  {
    "key": "visibility",
    "default": true
  },
  {
    "key": "startYear",
    "default": 2001
  },
  {
    "key": "endYear",
    "default": 2022
  }
]
```

- **ui_config**:

```json
{
  "@@type": "TreeCoverLossSettings",
  "endYear": "@@#params.endYear",
  "startYear": "@@#params.startYear",
  "description": "Displaying Tree cover loss with >30% canopy density."
}
```

## Tracking

- [ORC-94](https://vizzuality.atlassian.net/browse/ORC-94) - Land cover/land use layers (GFW)
  - [ORC-345](https://vizzuality.atlassian.net/browse/ORC-345) - FE - Implement the year selector for the Tree Cover Loss layer

[ORC-94]: https://vizzuality.atlassian.net/browse/ORC-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ