### PR TITLE
Add more mandatory fields. Fix focus and scroll on first error

### DIFF
--- a/client/src/app/(modules)/network/(form)/new/project/page.tsx
+++ b/client/src/app/(modules)/network/(form)/new/project/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import { SubmitHandler, useForm, ControllerRenderProps } from 'react-hook-form';
 
@@ -191,9 +191,7 @@ export default function ProjectForm() {
     },
     project_type: {
       label: 'Project type',
-      zod: z
-        .enum(projectTypes?.map((type) => type.id.toString()) as [string, ...string[]])
-        .optional(),
+      zod: z.enum(projectTypes?.map((type) => type.id.toString()) as [string, ...string[]]),
       type: 'select',
       options: projectTypes?.map((type) => ({
         label: type.name,
@@ -213,9 +211,7 @@ export default function ProjectForm() {
     },
     country_of_coordination: {
       label: 'Country of coordination',
-      zod: z
-        .enum(countries?.map((type) => type?.id?.toString()) as [string, ...string[]])
-        .optional(),
+      zod: z.enum(countries?.map((type) => type?.id?.toString()) as [string, ...string[]]),
       type: 'select',
       options: countries?.map((country) => ({
         label: country?.name,
@@ -246,9 +242,9 @@ export default function ProjectForm() {
     },
     main_area_of_intervention: {
       label: 'Main area of intervention',
-      zod: z
-        .enum(areasOfIntervention?.map((type) => type?.id?.toString()) as [string, ...string[]])
-        .optional(),
+      zod: z.enum(
+        areasOfIntervention?.map((type) => type?.id?.toString()) as [string, ...string[]],
+      ),
       type: 'select',
       options: areasOfIntervention?.map((area) => ({
         label: area?.name,
@@ -358,8 +354,32 @@ export default function ProjectForm() {
 
   const form = useForm<FormValues>({
     resolver: zodResolver(fields ? formSchema : z.object({})),
+    // Use custom useEffect to set focus and scroll to the first error as the order was failing
+    shouldFocusError: false,
   });
-  const { handleSubmit, watch } = form;
+  const {
+    handleSubmit,
+    watch,
+    setFocus,
+    formState: { errors },
+  } = form;
+
+  useEffect(() => {
+    const firstError = (Object.keys(errors) as Array<keyof typeof errors>).reduce<
+      keyof typeof errors | null
+    >((field, a) => {
+      const fieldKey = field as keyof typeof errors;
+      return !!errors[fieldKey] ? fieldKey : a;
+    }, null);
+
+    if (firstError) {
+      setFocus(String(firstError));
+      const field = document.querySelector(`[name="${firstError}"]`);
+      if (field) {
+        field.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }
+  }, [errors, setFocus]);
 
   const router = useRouter();
 

--- a/client/src/components/form/input-component.tsx
+++ b/client/src/components/form/input-component.tsx
@@ -68,13 +68,17 @@ const InputComponent = ({
 
     return (
       <Select
-        name={name}
         onValueChange={onChange}
         defaultValue={value as string | undefined}
         {...registerProjectsField}
         required={required}
       >
-        <SelectTrigger id={id} aria-describedby={ariaDescribedBy} aria-invalid={!!ariaInvalid}>
+        <SelectTrigger
+          id={id}
+          name={name}
+          aria-describedby={ariaDescribedBy}
+          aria-invalid={!!ariaInvalid}
+        >
           <span className="max-w-full truncate">
             <SelectValue placeholder={placeholder || 'Select'} />
           </span>
@@ -177,24 +181,24 @@ const InputComponent = ({
               name === 'start_date' || !startDate
                 ? new Date(+new Date() - 100 * 365 * 24 * 3600 * 1000)
                 : // We're making sure the user can't select the same date in both date
-                  // pickers because the API considers the max date as exclusive
-                  new Date(+new Date(startDate) + 24 * 3600 * 1000)
+                // pickers because the API considers the max date as exclusive
+                new Date(+new Date(startDate) + 24 * 3600 * 1000)
             }
             toDate={
               name === 'end_date' || !endDate
                 ? new Date(+new Date() + 100 * 365 * 24 * 3600 * 1000)
                 : // We're making sure the user can't select the same date in both date
-                  // pickers because the API considers the max date as exclusive
-                  new Date(+new Date(endDate) - 24 * 3600 * 1000)
+                // pickers because the API considers the max date as exclusive
+                new Date(+new Date(endDate) - 24 * 3600 * 1000)
             }
             selected={value ? new Date(value as string) : undefined}
             onSelect={(date: Date | undefined) =>
               onChange(
                 date
                   ? `${date.getFullYear()}-${`${date.getMonth() + 1}`.padStart(
-                      2,
-                      '0',
-                    )}-${`${date.getDate()}`.padStart(2, '0')}`
+                    2,
+                    '0',
+                  )}-${`${date.getDate()}`.padStart(2, '0')}`
                   : undefined,
               )
             }


### PR DESCRIPTION
This PR fixes two problems on the error form:

- Project type, Country of coordination, Main area of intervention should be mandatory

- The scroll when we try to submit should go to the first error. It was going always to the input