### PR TITLE
Feature/soils revealed UI

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-slider": "^1.1.2",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-switch": "^1.0.3",
+    "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.4",
     "@radix-ui/react-tooltip": "^1.0.6",
     "@t3-oss/env-nextjs": "0.4.1",

--- a/client/src/components/ui/tabs.tsx
+++ b/client/src/components/ui/tabs.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import * as React from 'react';
+
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from '@/lib/classnames';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex h-10 items-center justify-center border border-gray-300 p-1 text-white',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap px-3 py-1 text-base font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className,
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/client/src/containers/layer-groups-list/layers/layer.tsx
+++ b/client/src/containers/layer-groups-list/layers/layer.tsx
@@ -159,7 +159,11 @@ export default function Layer({ id, attributes = {} }: LayerGroupLayersDataItem)
           />
         </div>
       </header>
-      {isActive ? layerSettings : <div className="flex justify-end">{sourceLink}</div>}
+      {isActive && layerSettings ? (
+        layerSettings
+      ) : (
+        <div className="flex justify-end">{sourceLink}</div>
+      )}
     </li>
   );
 }

--- a/client/src/containers/layer-groups-list/layers/layer.tsx
+++ b/client/src/containers/layer-groups-list/layers/layer.tsx
@@ -81,6 +81,23 @@ export default function Layer({ id, attributes = {} }: LayerGroupLayersDataItem)
     }
   }, [id, layers, setLayers]);
 
+  const isActive = id && layers.includes(id);
+
+  const sourceLink = (
+    <a
+      href={attributes.source_url}
+      target="_blank"
+      rel="noreferrer"
+      className={cn({
+        'font-semibold hover:underline': true,
+        'text-yellow-600': !isActive,
+        'text-white': isActive,
+      })}
+    >
+      {attributes.source}
+    </a>
+  );
+
   const layerSettings = useMemo(() => {
     if (!id || !attributes.ui_settings) {
       return null;
@@ -95,6 +112,7 @@ export default function Layer({ id, attributes = {} }: LayerGroupLayersDataItem)
     if (component) {
       return cloneElement(component, {
         paramsConfig: attributes.params_config,
+        sourceLink,
         onChangeSettings: (settings: Record<string, unknown>) =>
           setLayersSettings((previousSettings) => ({
             ...previousSettings,
@@ -107,14 +125,10 @@ export default function Layer({ id, attributes = {} }: LayerGroupLayersDataItem)
     }
 
     return component;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [attributes, id, layersSettings, setLayersSettings]);
 
-  if (!id) {
-    return null;
-  }
-
-  const isActive = layers.includes(id);
-
+  if (!id) return null;
   return (
     <li
       key={id}
@@ -145,21 +159,7 @@ export default function Layer({ id, attributes = {} }: LayerGroupLayersDataItem)
           />
         </div>
       </header>
-      {isActive && layerSettings}
-      <div className="flex justify-end">
-        <a
-          href={attributes.source_url}
-          target="_blank"
-          rel="noreferrer"
-          className={cn({
-            'font-semibold hover:underline': true,
-            'text-yellow-600': !isActive,
-            'text-white': isActive,
-          })}
-        >
-          {attributes.source}
-        </a>
-      </div>
+      {isActive ? layerSettings : <div className="flex justify-end">{sourceLink}</div>}
     </li>
   );
 }

--- a/client/src/containers/layer-groups-list/settings/sois-revealed-settings.tsx
+++ b/client/src/containers/layer-groups-list/settings/sois-revealed-settings.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from 'react';
+
+import { cn } from '@/lib/classnames';
+
+import {
+  Tabs,
+  // TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs';
+export interface SoilsRevealedSettings {
+  depth: {
+    label?: number;
+    value: number;
+  };
+  timeFrame: {
+    label?: number;
+    value: number;
+  };
+  tabs: Record<string, string>;
+  onChangeSettings: (settings: Record<string, unknown>) => unknown;
+  sourceLink: JSX.Element;
+}
+
+const SoilsRevealedSettings: React.FC<SoilsRevealedSettings> = ({
+  timeFrame,
+  depth,
+  tabs,
+  onChangeSettings,
+  sourceLink,
+}) => {
+  const options = useMemo(
+    () =>
+      tabs &&
+      Object.entries(tabs)
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([label, value]) => ({
+          label: label,
+          value: value,
+        })),
+    [tabs],
+  );
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-x-4">
+        {tabs && (
+          <Tabs
+            defaultValue={options[0].value}
+            onValueChange={(value) => onChangeSettings({ tilesURL: [value] })}
+          >
+            <TabsList>
+              {options.map(({ label, value }) => (
+                <TabsTrigger key={value} value={value}>
+                  {label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            {/* {options.map(({ label, value }) => (
+              <TabsContent key={value} value={value}>
+                {label}
+              </TabsContent>
+            ))} */}
+          </Tabs>
+        )}
+        {timeFrame?.value}
+      </div>
+      <div
+        className={cn('flex ', { 'justify-between': depth?.value, 'justify-end': !depth?.value })}
+      >
+        {depth?.value}
+        {sourceLink}
+      </div>
+    </>
+  );
+};
+
+export default SoilsRevealedSettings;

--- a/client/src/containers/layer-groups-list/settings/sois-revealed-settings.tsx
+++ b/client/src/containers/layer-groups-list/settings/sois-revealed-settings.tsx
@@ -3,11 +3,13 @@ import { useMemo } from 'react';
 import { cn } from '@/lib/classnames';
 
 import {
-  Tabs,
-  // TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/tabs';
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+} from '@/components/ui/select';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 export interface SoilsRevealedSettings {
   depth: {
     label?: number;
@@ -18,6 +20,7 @@ export interface SoilsRevealedSettings {
     value: number;
   };
   tabs: Record<string, string>;
+  scenarios: Record<string, string>;
   onChangeSettings: (settings: Record<string, unknown>) => unknown;
   sourceLink: JSX.Element;
 }
@@ -26,10 +29,11 @@ const SoilsRevealedSettings: React.FC<SoilsRevealedSettings> = ({
   timeFrame,
   depth,
   tabs,
+  scenarios,
   onChangeSettings,
   sourceLink,
 }) => {
-  const options = useMemo(
+  const tabOptions = useMemo(
     () =>
       tabs &&
       Object.entries(tabs)
@@ -40,34 +44,66 @@ const SoilsRevealedSettings: React.FC<SoilsRevealedSettings> = ({
         })),
     [tabs],
   );
+  const scenarioOptions = useMemo(
+    () =>
+      scenarios &&
+      Object.entries(scenarios)
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([label, value]) => ({
+          label: label,
+          value: value,
+        })),
+    [scenarios],
+  );
 
   return (
     <>
       <div className="flex items-center justify-between gap-x-4">
         {tabs && (
           <Tabs
-            defaultValue={options[0].value}
+            defaultValue={tabOptions[0].value}
             onValueChange={(value) => onChangeSettings({ tilesURL: [value] })}
           >
             <TabsList>
-              {options.map(({ label, value }) => (
+              {tabOptions.map(({ label, value }) => (
                 <TabsTrigger key={value} value={value}>
                   {label}
                 </TabsTrigger>
               ))}
             </TabsList>
-            {/* {options.map(({ label, value }) => (
-              <TabsContent key={value} value={value}>
-                {label}
-              </TabsContent>
-            ))} */}
           </Tabs>
         )}
-        {timeFrame?.value}
+        {scenarios && (
+          <Select
+            value={scenarioOptions[0].value}
+            onValueChange={(value) => onChangeSettings({ tilesURL: [value] })}
+          >
+            <SelectTrigger id="scenarios" className="h-12 w-auto">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {scenarioOptions.map(({ label, value }) => (
+                <SelectItem key={value} value={value} className="w-full">
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        {!timeFrame.label && <div>{timeFrame?.value}</div>}
       </div>
       <div
-        className={cn('flex ', { 'justify-between': depth?.value, 'justify-end': !depth?.value })}
+        className={cn('flex ', {
+          'justify-between': depth?.value || timeFrame?.label,
+          'justify-end': !depth?.value && !timeFrame?.label,
+        })}
       >
+        {timeFrame?.label && (
+          <div>
+            <span className="font-semibold">{timeFrame.label}: </span>
+            {timeFrame?.value}
+          </div>
+        )}
         {depth?.value}
         {sourceLink}
       </div>

--- a/client/src/containers/layer-groups-list/settings/sois-revealed-settings.tsx
+++ b/client/src/containers/layer-groups-list/settings/sois-revealed-settings.tsx
@@ -23,11 +23,13 @@ export interface SoilsRevealedSettings {
   scenarios: Record<string, string>;
   onChangeSettings: (settings: Record<string, unknown>) => unknown;
   sourceLink: JSX.Element;
+  tilesURL: string[];
 }
 
 const SoilsRevealedSettings: React.FC<SoilsRevealedSettings> = ({
-  timeFrame,
   depth,
+  timeFrame,
+  tilesURL,
   tabs,
   scenarios,
   onChangeSettings,
@@ -40,7 +42,7 @@ const SoilsRevealedSettings: React.FC<SoilsRevealedSettings> = ({
         .sort((a, b) => a[0].localeCompare(b[0]))
         .map(([label, value]) => ({
           label: label,
-          value: value,
+          value: value?.[0],
         })),
     [tabs],
   );
@@ -51,7 +53,7 @@ const SoilsRevealedSettings: React.FC<SoilsRevealedSettings> = ({
         .sort((a, b) => a[0].localeCompare(b[0]))
         .map(([label, value]) => ({
           label: label,
-          value: value,
+          value: value?.[0],
         })),
     [scenarios],
   );
@@ -61,7 +63,7 @@ const SoilsRevealedSettings: React.FC<SoilsRevealedSettings> = ({
       <div className="flex items-center justify-between gap-x-4">
         {tabs && (
           <Tabs
-            defaultValue={tabOptions[0].value}
+            defaultValue={tilesURL?.[0]}
             onValueChange={(value) => onChangeSettings({ tilesURL: [value] })}
           >
             <TabsList>
@@ -75,7 +77,7 @@ const SoilsRevealedSettings: React.FC<SoilsRevealedSettings> = ({
         )}
         {scenarios && (
           <Select
-            value={scenarioOptions[0].value}
+            value={tilesURL?.[0]}
             onValueChange={(value) => onChangeSettings({ tilesURL: [value] })}
           >
             <SelectTrigger id="scenarios" className="h-12 w-auto">

--- a/client/src/containers/map/layer-manager/item.tsx
+++ b/client/src/containers/map/layer-manager/item.tsx
@@ -80,10 +80,12 @@ const LayerManagerItem = ({ id, beforeId, settings }: LayerManagerItemProps) => 
     const bounds = highlighted_bounds as number[][] | null;
 
     if (!c) return null;
-
+    // We need to add a key when we replace the tiles only for raster layers as it will fail on source change
+    const keyProp = c.source.type === 'raster' ? { key: c.source.tiles?.toString() } : {};
     return (
       <>
         <MapboxLayer
+          {...keyProp}
           id={`${id}-layer`}
           beforeId={beforeId}
           config={c}

--- a/client/src/lib/json-converter/index.ts
+++ b/client/src/lib/json-converter/index.ts
@@ -7,6 +7,7 @@ import FUNCTIONS from '@/lib/utils';
 
 import { ParamsConfig } from '@/types/layers';
 
+import SoilsRevealedSettings from '@/containers/layer-groups-list/settings/sois-revealed-settings';
 import TreeCoverLossSettings from '@/containers/layer-groups-list/settings/tree-cover-loss';
 
 import DecodeLayer from '@/components/map/layers/decode-layer';
@@ -26,6 +27,7 @@ export const JSON_CONFIGURATION = new JSONConfiguration({
     LegendTypeChoropleth,
     LegendTypeGradient,
     TreeCoverLossSettings,
+    SoilsRevealedSettings,
   },
 });
 

--- a/client/src/types/layers.ts
+++ b/client/src/types/layers.ts
@@ -1,16 +1,13 @@
-import { MapStyle } from 'react-map-gl/maplibre';
+import { AnySource } from 'react-map-gl';
 
-interface SourceData {
-  id: string;
-  type: 'vector' | 'raster' | 'raster-dem' | 'geojson' | 'image' | 'video';
-}
+import { MapStyle } from 'react-map-gl/maplibre';
 
 import { FormatProps } from '@/lib/utils/formats';
 
 import type { Layer } from '@/types/generated/strapi.schemas';
 
 export type Config = {
-  source: SourceData;
+  source: AnySource;
   styles: MapStyle['layers'];
 };
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2829,6 +2829,7 @@ __metadata:
     "@radix-ui/react-slider": "npm:^1.1.2"
     "@radix-ui/react-slot": "npm:^1.0.2"
     "@radix-ui/react-switch": "npm:^1.0.3"
+    "@radix-ui/react-tabs": "npm:^1.0.4"
     "@radix-ui/react-toast": "npm:^1.1.4"
     "@radix-ui/react-tooltip": "npm:^1.0.6"
     "@svgr/webpack": "npm:^8.1.0"
@@ -3691,6 +3692,33 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: b5ee2c0ec92feaf8100ddbb2bb1a4a1dc42c2350e31aedf3d595b21c8a8686d338bde940985007635cec43134f9a6712e301d85fa6df352cb716e6745be5d37a
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-tabs@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@radix-ui/react-tabs@npm:1.0.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.13.10"
+    "@radix-ui/primitive": "npm:1.0.1"
+    "@radix-ui/react-context": "npm:1.0.1"
+    "@radix-ui/react-direction": "npm:1.0.1"
+    "@radix-ui/react-id": "npm:1.0.1"
+    "@radix-ui/react-presence": "npm:1.0.1"
+    "@radix-ui/react-primitive": "npm:1.0.3"
+    "@radix-ui/react-roving-focus": "npm:1.0.4"
+    "@radix-ui/react-use-controllable-state": "npm:1.0.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 9d2d6e3d922e95274b5b205efbac2749d4e3ef9106fe270213dd178dec7411908c9a639f204e3eeb2c5e982a512fdda98a55a8e1a789cfc844ebd51425af0539
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/ORC-347?atlOrigin=eyJpIjoiNzdjODc2ZTc5ZGM0NDFmZGIwNDEzMDk3YTgwN2M1NDIiLCJwIjoiaiJ9

This PR allows to present the Soils Revealed layers with an UI that can switch between different layers with just one strapi layer. This requires the config with the config_ui parameter on strapi. Also we need to rerender the Mapbox Layer component using a different key when we update the tiles as it won't work on rasters (it will ask to remove and add a different source)