### PR TITLE
Remove publication_status from frontend

### DIFF
--- a/client/src/hooks/networks/index.ts
+++ b/client/src/hooks/networks/index.ts
@@ -102,15 +102,6 @@ export enum NetworkProjectStatusFilter {
   NotStarted,
 }
 
-const ACCEPTED_STATUS_FILTER = {
-  $or: [
-    {
-      publication_status: { $eq: 'accepted' },
-    },
-    { publication_status: { $null: true } },
-  ],
-};
-
 const getQueryFilters = (filters: NetworkFilters) => {
   const generalFilters =
     typeof filters.search !== 'undefined' && filters.search.length > 0
@@ -332,10 +323,10 @@ const getQueryFilters = (filters: NetworkFilters) => {
 
   return {
     organization: {
-      $and: [...generalFilters, ...organizationFilters, ACCEPTED_STATUS_FILTER],
+      $and: [...generalFilters, ...organizationFilters],
     },
     project: {
-      $and: [...generalFilters, ...projectFilters, ACCEPTED_STATUS_FILTER],
+      $and: [...generalFilters, ...projectFilters],
     },
   };
 };


### PR DESCRIPTION
As the publication_status field is not used anymore we are removing it from the filters on the frontend. This was crashing the application before.

@tiagojsag Please remove all related CMS code if needed