### PR TITLE
[Practices] Only show relevant practices

### DIFF
--- a/client/src/app/(modules)/practices/(main)/(details)/[id]/page.tsx
+++ b/client/src/app/(modules)/practices/(main)/(details)/[id]/page.tsx
@@ -18,7 +18,9 @@ export async function generateMetadata({ params }: PracticeDetailsProps): Promis
   const id = parseInt(params.id);
   const data = await getPracticesId(id);
   const practice = data?.data?.attributes;
-  if (!practice) {
+
+  // If we couldn't find the practice or it is not relevant, we don't return any metadata
+  if (!practice || !practice.show) {
     return {};
   }
 
@@ -32,7 +34,8 @@ export default async function PracticeDetails({ params }: PracticeDetailsProps) 
   const data = await getPracticesId(id, { populate: '*' });
   const practice = data?.data?.attributes;
 
-  if (!practice) {
+  // If we couldn't find the practice or it is not relevant, we display a 404
+  if (!practice || !practice.show) {
     notFound();
   }
 

--- a/client/src/hooks/practices/index.ts
+++ b/client/src/hooks/practices/index.ts
@@ -96,7 +96,18 @@ const getQueryFilters = (filters: PracticesFilters) => {
       : []),
   ];
 
-  return { $and: [...generalFilters, ...practiceFilters] };
+  return {
+    $and: [
+      // We filter out non-relevant practices
+      {
+        show: {
+          $eq: true,
+        },
+      },
+      ...generalFilters,
+      ...practiceFilters,
+    ],
+  };
 };
 
 export const usePractices = ({


### PR DESCRIPTION
This PR filters out non-relevant practices from the Practices module.

## Acceptance criteria

- Visitors can only see practices that have the field `show` set to `true` in the back-office
  - Applies to the list, map and detailed view

## Tracking

[ORC-436](https://vizzuality.atlassian.net/browse/ORC-436)

[ORC-436]: https://vizzuality.atlassian.net/browse/ORC-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ