### PR TITLE
[Network] Allow visitors to filter projects by “Active on year”

### DIFF
--- a/client/src/app/(modules)/network/(main)/filters-sidebar.tsx
+++ b/client/src/app/(modules)/network/(main)/filters-sidebar.tsx
@@ -167,6 +167,7 @@ export default function FiltersSidebar() {
                   ...filters,
                   projectType: [],
                   status: [],
+                  year: [],
                   coordinationCountry: [],
                   interventionRegion: [],
                   interventionCountry: [],
@@ -190,6 +191,13 @@ export default function FiltersSidebar() {
                 value={filters.status ?? []}
                 options={projectFiltersOptions.status}
                 onChange={(value) => setFilters({ ...filters, status: value })}
+              />
+              <MultiCombobox
+                name="Active on year"
+                variant="network-project"
+                value={filters.year ?? []}
+                options={projectFiltersOptions.year}
+                onChange={(value) => setFilters({ ...filters, year: value })}
               />
               <MultiCombobox
                 name="Country of coordination"

--- a/client/src/hooks/networks/index.ts
+++ b/client/src/hooks/networks/index.ts
@@ -258,6 +258,28 @@ const getQueryFilters = (filters: NetworkFilters) => {
           },
         ]
       : []),
+    ...(filters.year.length > 0
+      ? [
+          {
+            $or: filters.year.map((value) => {
+              return {
+                $and: [
+                  {
+                    start_date: {
+                      $lte: `${value}-12-31`,
+                    },
+                  },
+                  {
+                    end_date: {
+                      $gte: `${value}-01-01`,
+                    },
+                  },
+                ],
+              };
+            }),
+          },
+        ]
+      : []),
     ...(filters.coordinationCountry.length > 0
       ? [
           {
@@ -935,5 +957,10 @@ export const useNetworkProjectFiltersOptions = (): Record<
       { label: 'Finished', value: NetworkProjectStatusFilter.Finished },
       { label: 'Not started', value: NetworkProjectStatusFilter.NotStarted },
     ],
+    // NOTE: 2010 is the hard-coded start year for the filter
+    year: Array.from({ length: new Date().getFullYear() - 2010 + 1 }).map((_, index) => ({
+      label: `${2010 + index}`,
+      value: 2010 + index,
+    })),
   };
 };

--- a/client/src/store/network.ts
+++ b/client/src/store/network.ts
@@ -16,6 +16,7 @@ export interface NetworkOrganizationFilters {
 export interface NetworkProjectFilters {
   projectType: number[];
   status: number[];
+  year: number[];
   coordinationCountry: number[];
   interventionRegion: number[];
   interventionCountry: number[];
@@ -35,6 +36,7 @@ const organizationFiltersKeys: (keyof NetworkOrganizationFilters)[] = [
 const projectFiltersKeys: (keyof NetworkProjectFilters)[] = [
   'projectType',
   'status',
+  'year',
   'coordinationCountry',
   'interventionRegion',
   'interventionCountry',
@@ -53,6 +55,7 @@ const filtersAtom = atom<NetworkFilters>({
   country: [],
   projectType: [],
   status: [],
+  year: [],
   coordinationCountry: [],
   interventionRegion: [],
   interventionCountry: [],


### PR DESCRIPTION
This PR allows visitors of the Network module to filter projects by years in which they were active.

## Acceptance criteria

- There is a way for visitors to filter projects by year
  - Only the projects active (even partially) during that year will be matched
  - Applies to the list of projects and the map
  - The filter will be named: “Active on year”
  - The filter is displayed below the “Status” filter
  - The user is able to filter projects between **2010** and the current year
    - Sorted ascending
- There is a way for visitors to reset all project filters
- There is an indication of how many filters are set
  - Shown next to the “Filters” button that toggles the filters sidebar

## Tracking

[ORC-414](https://vizzuality.atlassian.net/browse/ORC-414)

[ORC-414]: https://vizzuality.atlassian.net/browse/ORC-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ