### PR TITLE
[Network] Display the number of results

### DIFF
--- a/client/src/app/(modules)/network/(main)/page.tsx
+++ b/client/src/app/(modules)/network/(main)/page.tsx
@@ -13,7 +13,7 @@ import { useFiltersCount, useNetworkFilterSidebarOpen, useNetworkFilters } from 
 
 import { useGetPages } from '@/types/generated/page';
 
-import { useNetworks } from '@/hooks/networks';
+import { useNetworks, useNetworksCount } from '@/hooks/networks';
 
 import { useSidebarScrollHelpers } from '@/containers/sidebar';
 
@@ -33,6 +33,8 @@ export default function NetworkModule() {
   const { attributes: { intro = undefined } = {} } = data || {};
 
   const networks = useNetworks({ filters });
+  const networksCount = useNetworksCount(filters);
+
   // The keywords search is not counted because it's shown in the main sidebar
   const filtersCount = useFiltersCount(filters, ['search']);
 
@@ -43,6 +45,9 @@ export default function NetworkModule() {
   const [savedSidebarScroll, setSavedSidebarScroll] = useSidebarScroll();
 
   const filtersButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  const loadOrganizations = !filters.type?.length || filters.type.includes('organization');
+  const loadProjects = !filters.type?.length || filters.type.includes('project');
 
   // We store the sidebar's scroll position when navigating away from the list view. `useEffect`
   // can't be used because it would be executed after repainting i.e. after navigating.
@@ -117,7 +122,18 @@ export default function NetworkModule() {
           )}
         </Button>
       </div>
-      <NetworkList {...networks} />
+      <div className="border-t border-dashed border-t-gray-300 pt-6 text-sm text-gray-500">
+        {loadOrganizations &&
+          loadProjects &&
+          `Showing ${networksCount.organisation} organisations and ${networksCount.project} projects.`}
+        {loadOrganizations &&
+          !loadProjects &&
+          `Showing ${networksCount.organisation} organisations.`}
+        {!loadOrganizations && loadProjects && `Showing ${networksCount.project} projects.`}
+      </div>
+      <div className="!mt-6">
+        <NetworkList {...networks} />
+      </div>
       {env.NEXT_PUBLIC_HIDE_NETWORK_FORMS !== 'true' && renderFormButtons}
     </div>
   );

--- a/client/src/hooks/networks/index.ts
+++ b/client/src/hooks/networks/index.ts
@@ -773,6 +773,48 @@ export const useNetworks = ({ size = 20, filters }: { size?: number; filters: Ne
   };
 };
 
+export const useNetworksCount = (filters: NetworkFilters) => {
+  const loadOrganizations = !filters.type?.length || filters.type.includes('organization');
+  const loadProjects = !filters.type?.length || filters.type.includes('project');
+
+  const queryFilters = getQueryFilters(filters);
+
+  const { data: organizationsData } = useGetOrganizations(
+    {
+      fields: 'id',
+      'pagination[pageSize]': 9999,
+      filters: queryFilters.organization,
+    },
+    {
+      query: {
+        queryKey: ['organization', 'count', filters],
+        keepPreviousData: true,
+        enabled: loadOrganizations,
+      },
+    },
+  );
+
+  const { data: projectsData } = useGetProjects(
+    {
+      fields: 'id',
+      'pagination[pageSize]': 9999,
+      filters: queryFilters.project,
+    },
+    {
+      query: {
+        queryKey: ['project', 'count', filters],
+        keepPreviousData: true,
+        enabled: loadProjects,
+      },
+    },
+  );
+
+  return {
+    organisation: organizationsData?.meta?.pagination?.total ?? 0,
+    project: projectsData?.meta?.pagination?.total ?? 0,
+  };
+};
+
 export const useNetworkOrganizationFiltersOptions = (): Record<
   keyof NetworkOrganizationFilters,
   { label: string; value: number }[]

--- a/client/src/hooks/networks/index.ts
+++ b/client/src/hooks/networks/index.ts
@@ -782,7 +782,7 @@ export const useNetworksCount = (filters: NetworkFilters) => {
   const { data: organizationsData } = useGetOrganizations(
     {
       fields: 'id',
-      'pagination[pageSize]': 9999,
+      'pagination[pageSize]': 1,
       filters: queryFilters.organization,
     },
     {


### PR DESCRIPTION
This PR displays the number of results (organisations and projects) at the top of the sidebar in the Network module.

## Acceptance criteria

- There is a way to see the total number of organisations and projects (and schemes) existing on the Network module
  - If a filter is selected, the total number of filtered organisations and/or projects (and schemes) is displayed
  - Text:
    - If organisations and projects: « Showing XXX organisations and YYY projects. »
    - If organisations only: « Showing XXX organisations. »
    - If projects only: « Showing YYY projects. »
  - Design: https://www.figma.com/file/DBXFTLd6nFBmg6fFE6P2cX/ORCaSa-Design?type=design&node-id=451-55221&mode=design&t=3h7O8hlr2NOHEAjj-4

## Tracking

- [ORC-415](https://vizzuality.atlassian.net/browse/ORC-415) - Display the total number of matching organisations and projects
  - [ORC-417](https://vizzuality.atlassian.net/browse/ORC-417) - FE - Indicate the total number of matching organisations and projects

[ORC-415]: https://vizzuality.atlassian.net/browse/ORC-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ORC-417]: https://vizzuality.atlassian.net/browse/ORC-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ