### PR TITLE
Update language frontend display for practices

### DIFF
--- a/client/src/app/(modules)/practices/(main)/(details)/parsers.ts
+++ b/client/src/app/(modules)/practices/(main)/(details)/parsers.ts
@@ -27,8 +27,7 @@ export const getPracticeFields = (practice: Practice): FieldType[] => {
   }
 
   if (language) {
-    //  TODO: Update this as it will be an iso array when the API is updated
-    fields.push({ label: 'Language', value: language?.sort((a, b) => a.length - b.length)[0] });
+    fields.push({ label: 'Language', value: language });
   }
 
   if (source && source.length > 0) {

--- a/client/src/app/(modules)/practices/(main)/practice.tsx
+++ b/client/src/app/(modules)/practices/(main)/practice.tsx
@@ -29,10 +29,7 @@ const Icons = ({ attributes }: { attributes: TypedPractice | undefined }) => {
 
       <div className="flex gap-2">
         <LanguageIcon className="h-6 w-6 min-w-min" />
-        <div className="text-base uppercase text-slate-500">
-          {/* TODO: Update this as it will be an iso array when the API is updated */}
-          {language?.sort((a, b) => a.length - b.length)[0]}
-        </div>
+        <div className="text-base uppercase text-slate-500">{language}</div>
       </div>
       {source_name === 'WOCAT' && (
         <Image


### PR DESCRIPTION
Update language field for practices as it has changed on Strapi.

Change from ['es', 'Spanish'] to 'ES, EN'

This PR is associated to this BE task: https://vizzuality.atlassian.net/browse/ORC-386?atlOrigin=eyJpIjoiMjFiNDliYzc4ZWM0NGRiNzkxZDE1NzYyYjZjMDNmYzIiLCJwIjoiaiJ9