### PR TITLE
Add mandatory fields in Project and Organization [ORC-410]

### DIFF
--- a/cms/src/api/organization/content-types/organization/lifecycles.ts
+++ b/cms/src/api/organization/content-types/organization/lifecycles.ts
@@ -20,16 +20,13 @@ export default {
     const organizationDelta = event.params.data;
     const organizationToUpdate: any = await strapi.entityService.findOne("api::organization.organization", event.params.where.id);
 
-    if ((!organizationToUpdate.organization_type && organizationDelta.organization_type.connect.length === 0) ||
-      (organizationDelta.organization_type.disconnect.length === 1 && organizationDelta.organization_type.connect.length === 0)) {
+    if (organizationDelta.organization_type.connect.length === 0 && (organizationDelta.organization_type.disconnect.length === 1 || !organizationToUpdate.organization_type)) {
       throw new ApplicationError('Organization Type is required');
     }
-    if ((!organizationToUpdate.main_organization_theme && organizationDelta.main_organization_theme.connect.length === 0) ||
-      (organizationDelta.main_organization_theme.disconnect.length === 1 && organizationDelta.main_organization_theme.connect.length === 0)) {
+    if (organizationDelta.main_organization_theme.connect.length === 0 && (organizationDelta.main_organization_theme.disconnect.length === 1 || !organizationToUpdate.main_organization_theme)) {
       throw new ApplicationError('Main Organization Theme is required');
     }
-    if ((!organizationToUpdate.country && organizationDelta.country.connect.length === 0) ||
-      (organizationDelta.country.disconnect.length === 1 && organizationDelta.country.connect.length === 0)) {
+    if (organizationDelta.country.connect.length === 0 && (organizationDelta.country.disconnect.length === 1 || !organizationToUpdate.country)) {
       throw new ApplicationError('Country is required');
     }
   },

--- a/cms/src/api/organization/content-types/organization/lifecycles.ts
+++ b/cms/src/api/organization/content-types/organization/lifecycles.ts
@@ -1,0 +1,36 @@
+import { errors } from "@strapi/utils";
+
+const { ApplicationError } = errors;
+
+export default {
+  beforeCreate(event) {
+    const organizationDelta = event.params.data;
+
+    if (organizationDelta.organization_type.connect.length === 0) {
+      throw new ApplicationError('Organization Type is required');
+    }
+    if (organizationDelta.main_organization_theme.connect.length === 0) {
+      throw new ApplicationError('Main Organization Theme is required');
+    }
+    if (organizationDelta.country.connect.length === 0) {
+      throw new ApplicationError('Country is required');
+    }
+  },
+  async beforeUpdate(event) {
+    const organizationDelta = event.params.data;
+    const organizationToUpdate: any = await strapi.entityService.findOne("api::organization.organization", event.params.where.id);
+
+    if ((!organizationToUpdate.organization_type && organizationDelta.organization_type.connect.length === 0) ||
+      (organizationDelta.organization_type.disconnect.length === 1 && organizationDelta.organization_type.connect.length === 0)) {
+      throw new ApplicationError('Organization Type is required');
+    }
+    if ((!organizationToUpdate.main_organization_theme && organizationDelta.main_organization_theme.connect.length === 0) ||
+      (organizationDelta.main_organization_theme.disconnect.length === 1 && organizationDelta.main_organization_theme.connect.length === 0)) {
+      throw new ApplicationError('Main Organization Theme is required');
+    }
+    if ((!organizationToUpdate.country && organizationDelta.country.connect.length === 0) ||
+      (organizationDelta.country.disconnect.length === 1 && organizationDelta.country.connect.length === 0)) {
+      throw new ApplicationError('Country is required');
+    }
+  },
+}

--- a/cms/src/api/organization/content-types/organization/schema.json
+++ b/cms/src/api/organization/content-types/organization/schema.json
@@ -20,6 +20,7 @@
     },
     "organization_type": {
       "type": "relation",
+      "required": true,
       "relation": "oneToOne",
       "target": "api::organization-type.organization-type"
     },
@@ -28,6 +29,7 @@
     },
     "main_organization_theme": {
       "type": "relation",
+      "required": true,
       "relation": "oneToOne",
       "target": "api::organization-theme.organization-theme"
     },
@@ -47,6 +49,7 @@
     },
     "country": {
       "type": "relation",
+      "required": true,
       "relation": "oneToOne",
       "target": "api::country.country"
     },

--- a/cms/src/api/project/content-types/project/lifecycles.ts
+++ b/cms/src/api/project/content-types/project/lifecycles.ts
@@ -11,23 +11,23 @@ export default {
       throw new ApplicationError('Project Type is required');
     }
     if (projectDelta.lead_partner.connect.length === 0) {
-      throw new ApplicationError('Main Organization Theme is required');
+      throw new ApplicationError('Lead Partner is required');
     }
     if (projectDelta.country_of_coordination.connect.length === 0) {
-      throw new ApplicationError('Country is required');
+      throw new ApplicationError('Country of Coordination is required');
     }
   },
   async beforeUpdate(event) {
     const projectToUpdate: any = await strapi.entityService.findOne("api::project.project", event.params.where.id);
     const projectDelta = event.params.data;
 
-    if ((!projectToUpdate.project_type && projectDelta.project_type.connect.length === 0) || (projectDelta.project_type.disconnect.length === 1 && projectDelta.project_type.connect.length === 0)) {
+    if (projectDelta.project_type.connect.length === 0 && (projectDelta.project_type.disconnect.length === 1 || !projectToUpdate.project_type)) {
       throw new ApplicationError('Project Type is required');
     }
-    if ((!projectToUpdate.lead_partner && projectDelta.lead_partner.connect.length === 0) ||(projectDelta.lead_partner.disconnect.length === 1 && projectDelta.lead_partner.connect.length === 0)) {
+    if (projectDelta.lead_partner.connect.length === 0 && (projectDelta.lead_partner.disconnect.length === 1 || !projectToUpdate.lead_partner)) {
       throw new ApplicationError('Lead Partner is required');
     }
-    if ((!projectToUpdate.country_of_coordination && projectDelta.country_of_coordination.connect.length === 0) || (projectDelta.country_of_coordination.disconnect.length === 1 && projectDelta.country_of_coordination.connect.length === 0)) {
+    if (projectDelta.country_of_coordination.connect.length === 0 && (projectDelta.country_of_coordination.disconnect.length === 1 || !projectToUpdate.country_of_coordination)) {
       throw new ApplicationError('Country of Coordination is required');
     }
   }

--- a/cms/src/api/project/content-types/project/lifecycles.ts
+++ b/cms/src/api/project/content-types/project/lifecycles.ts
@@ -1,0 +1,36 @@
+import { errors } from "@strapi/utils";
+
+const { ApplicationError } = errors;
+
+export default {
+
+  beforeCreate(event) {
+    const projectDelta = event.params.data;
+
+    if (projectDelta.project_type.connect.length === 0) {
+      throw new ApplicationError('Project Type is required');
+    }
+    if (projectDelta.lead_partner.connect.length === 0) {
+      throw new ApplicationError('Main Organization Theme is required');
+    }
+    if (projectDelta.country_of_coordination.connect.length === 0) {
+      throw new ApplicationError('Country is required');
+    }
+  },
+  async beforeUpdate(event) {
+    const projectToUpdate: any = await strapi.entityService.findOne("api::project.project", event.params.where.id);
+    const projectDelta = event.params.data;
+
+    if ((!projectToUpdate.project_type && projectDelta.project_type.connect.length === 0) || (projectDelta.project_type.disconnect.length === 1 && projectDelta.project_type.connect.length === 0)) {
+      throw new ApplicationError('Project Type is required');
+    }
+    if ((!projectToUpdate.lead_partner && projectDelta.lead_partner.connect.length === 0) ||(projectDelta.lead_partner.disconnect.length === 1 && projectDelta.lead_partner.connect.length === 0)) {
+      throw new ApplicationError('Lead Partner is required');
+    }
+    if ((!projectToUpdate.country_of_coordination && projectDelta.country_of_coordination.connect.length === 0) || (projectDelta.country_of_coordination.disconnect.length === 1 && projectDelta.country_of_coordination.connect.length === 0)) {
+      throw new ApplicationError('Country of Coordination is required');
+    }
+  }
+}
+
+

--- a/cms/src/api/project/content-types/project/schema.json
+++ b/cms/src/api/project/content-types/project/schema.json
@@ -19,6 +19,7 @@
     },
     "project_type": {
       "type": "relation",
+      "required": true,
       "relation": "oneToOne",
       "target": "api::project-type.project-type"
     },
@@ -40,6 +41,7 @@
     },
     "country_of_coordination": {
       "type": "relation",
+      "required": true,
       "relation": "oneToOne",
       "target": "api::country.country"
     },
@@ -96,6 +98,7 @@
     },
     "lead_partner": {
       "type": "relation",
+      "required": true,
       "relation": "manyToOne",
       "target": "api::organization.organization",
       "inversedBy": "lead_projects"

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -1118,13 +1118,15 @@ export interface ApiOrganizationOrganization extends Schema.CollectionType {
       'api::organization.organization',
       'oneToOne',
       'api::organization-type.organization-type'
-    >;
+    > &
+      Attribute.Required;
     organization_type_other: Attribute.String;
     main_organization_theme: Attribute.Relation<
       'api::organization.organization',
       'oneToOne',
       'api::organization-theme.organization-theme'
-    >;
+    > &
+      Attribute.Required;
     secondary_organization_theme: Attribute.Relation<
       'api::organization.organization',
       'oneToOne',
@@ -1143,7 +1145,8 @@ export interface ApiOrganizationOrganization extends Schema.CollectionType {
       'api::organization.organization',
       'oneToOne',
       'api::country.country'
-    >;
+    > &
+      Attribute.Required;
     url: Attribute.String & Attribute.Required;
     lead_projects: Attribute.Relation<
       'api::organization.organization',
@@ -1426,7 +1429,8 @@ export interface ApiProjectProject extends Schema.CollectionType {
       'api::project.project',
       'oneToOne',
       'api::project-type.project-type'
-    >;
+    > &
+      Attribute.Required;
     start_date: Attribute.Date & Attribute.Required;
     end_date: Attribute.Date;
     short_description: Attribute.Text &
@@ -1442,7 +1446,8 @@ export interface ApiProjectProject extends Schema.CollectionType {
       'api::project.project',
       'oneToOne',
       'api::country.country'
-    >;
+    > &
+      Attribute.Required;
     region_of_interventions: Attribute.Relation<
       'api::project.project',
       'manyToMany',
@@ -1483,7 +1488,8 @@ export interface ApiProjectProject extends Schema.CollectionType {
       'api::project.project',
       'manyToOne',
       'api::organization.organization'
-    >;
+    > &
+      Attribute.Required;
     partners: Attribute.Relation<
       'api::project.project',
       'manyToMany',


### PR DESCRIPTION
## Make some fields mandatory on the project and organisation models (Strapi).

Organization model
- Organization Type
- Main Organization Theme
- Country

Project model
- Project Type
- Lead Partner
- Country of Coordination

**Note:** currently in Staging data some organizations and projects have already been created with the mentioned attributes as null. The implementation, in case of updating, checks if the fields have null values in database and throws mandatory field error in case the field is not changed in update scope (no disconnect/connect values). This step is not necessary in case all Projects and Organization are created with the new mandatory fields restrictions. 

