### PR TITLE
Allow options to be passed to the `formatNumber` util

### DIFF
--- a/client/src/lib/utils/formats.ts
+++ b/client/src/lib/utils/formats.ts
@@ -34,10 +34,10 @@ const formatNumber = (value: number, options?: Intl.NumberFormatOptions) => {
 };
 
 // Only to remove strange numbers. Maybe it can be fixed in data
-const formatLayerNumber = (value: number) => {
+const formatLayerNumber = (value: number, options?: Intl.NumberFormatOptions) => {
   // The French number format uses spaces to separate thousands, millions, etc. and a comma to
   // separate the decimals e.g. 1 456 357,45
-  const formatter = Intl.NumberFormat('fr');
+  const formatter = Intl.NumberFormat('fr', options);
   // To avoid strange behaviour in the map, we don't display numbers that too small
   if (Number.isNaN(value)) return null;
   if (value < -10000000) return null;

--- a/client/src/lib/utils/formats.ts
+++ b/client/src/lib/utils/formats.ts
@@ -26,10 +26,10 @@ export function formatDate(value: string, options?: Intl.DateTimeFormatOptions) 
   return formatter.format(dateValue);
 }
 
-const formatNumber = (value: number) => {
+const formatNumber = (value: number, options?: Intl.NumberFormatOptions) => {
   // The French number format uses spaces to separate thousands, millions, etc. and a comma to
   // separate the decimals e.g. 1 456 357,45
-  const formatter = Intl.NumberFormat('fr');
+  const formatter = Intl.NumberFormat('fr', options);
   return formatter.format(value);
 };
 


### PR DESCRIPTION
This PR modifies the `formatNumber` util so that options can be passed to it.

This is especially relevant since the `format` function of the same file (which calls `formatNumber`) is used to parse the CMS' `interaction_config` field. `formatNumber` was the only formatter that didn't support external options.

## Tracking

Related to [ORC-384](https://vizzuality.atlassian.net/browse/ORC-384).

[ORC-384]: https://vizzuality.atlassian.net/browse/ORC-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ