### PR TITLE
 [Practices] Display the number of results

### DIFF
--- a/client/src/app/(modules)/network/(main)/page.tsx
+++ b/client/src/app/(modules)/network/(main)/page.tsx
@@ -125,11 +125,17 @@ export default function NetworkModule() {
       <div className="border-t border-dashed border-t-gray-300 pt-6 text-sm text-gray-500">
         {loadOrganizations &&
           loadProjects &&
-          `Showing ${networksCount.organisation} organisation(s) and ${networksCount.project} project(s).`}
+          `Showing ${networksCount.organisation} organisation${
+            networksCount.organisation > 1 ? 's' : ''
+          } and ${networksCount.project} project${networksCount.project > 1 ? 's' : ''}.`}
         {loadOrganizations &&
           !loadProjects &&
-          `Showing ${networksCount.organisation} organisation(s).`}
-        {!loadOrganizations && loadProjects && `Showing ${networksCount.project} project(s).`}
+          `Showing ${networksCount.organisation} organisation${
+            networksCount.organisation > 1 ? 's' : ''
+          }.`}
+        {!loadOrganizations &&
+          loadProjects &&
+          `Showing ${networksCount.project} project${networksCount.project > 1 ? 's' : ''}.`}
       </div>
       <div className="!mt-6">
         <NetworkList {...networks} />

--- a/client/src/app/(modules)/practices/(main)/page.tsx
+++ b/client/src/app/(modules)/practices/(main)/page.tsx
@@ -15,7 +15,7 @@ import {
 
 import { useGetPages } from '@/types/generated/page';
 
-import { usePractices } from '@/hooks/practices';
+import { usePractices, usePracticesCount } from '@/hooks/practices';
 
 import { useSidebarScrollHelpers } from '@/containers/sidebar';
 
@@ -35,6 +35,7 @@ export default function PracticesModule() {
   const previousFilters = usePreviousImmediate(filters);
 
   const practices = usePractices({ filters });
+  const practicesCount = usePracticesCount(filters);
   // The keywords search is not counted because it's shown in the main sidebar
   const filtersCount = useFiltersCount(filters, ['search']);
 
@@ -105,7 +106,12 @@ export default function PracticesModule() {
           )}
         </Button>
       </div>
-      <PracticeList {...practices} />
+      <div className="border-t border-dashed border-t-gray-300 pt-6 text-sm text-gray-500">
+        Showing {practicesCount} practice(s).
+      </div>
+      <div className="!mt-6">
+        <PracticeList {...practices} />
+      </div>
     </div>
   );
 }

--- a/client/src/app/(modules)/practices/(main)/page.tsx
+++ b/client/src/app/(modules)/practices/(main)/page.tsx
@@ -107,7 +107,7 @@ export default function PracticesModule() {
         </Button>
       </div>
       <div className="border-t border-dashed border-t-gray-300 pt-6 text-sm text-gray-500">
-        Showing {practicesCount} practice(s).
+        {`Showing ${practicesCount} practice${practicesCount > 1 ? 's' : ''}.`}
       </div>
       <div className="!mt-6">
         <PracticeList {...practices} />

--- a/client/src/hooks/practices/index.ts
+++ b/client/src/hooks/practices/index.ts
@@ -255,6 +255,26 @@ export const usePractices = ({
   };
 };
 
+export const usePracticesCount = (filters: PracticesFilters) => {
+  const queryFilters = getQueryFilters(filters);
+
+  const { data } = useGetPractices(
+    {
+      fields: ['id'],
+      'pagination[pageSize]': 1,
+      filters: queryFilters,
+    },
+    {
+      query: {
+        queryKey: ['practice', 'count', filters],
+        keepPreviousData: true,
+      },
+    },
+  );
+
+  return data?.meta?.pagination?.total ?? 0;
+};
+
 export type PointFeatureWithPracticeProperties = PointFeature<{
   countryName: string;
   practices: PracticesProperties[];

--- a/client/src/types/generated/strapi.schemas.ts
+++ b/client/src/types/generated/strapi.schemas.ts
@@ -1957,6 +1957,7 @@ export type SustainableDevGoalProjectsDataItemAttributesProjectTypeDataAttribute
 
 export type SustainableDevGoalProjectsDataItemAttributesProjectTypeDataAttributes = {
   name?: string;
+  description?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: SustainableDevGoalProjectsDataItemAttributesProjectTypeDataAttributesCreatedBy;
@@ -3106,6 +3107,7 @@ export type SubinterventionPracticesDataItemAttributesCountryDataAttributesRegio
 export type SubinterventionPracticesDataItemAttributesCountryDataAttributesRegionDataAttributesProjectsDataItemAttributesProjectTypeDataAttributes =
   {
     name?: string;
+    description?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: SubinterventionPracticesDataItemAttributesCountryDataAttributesRegionDataAttributesProjectsDataItemAttributesProjectTypeDataAttributesCreatedBy;
@@ -4619,6 +4621,7 @@ export type RegionProjectsDataItemAttributesProjectTypeDataAttributesUpdatedBy =
 
 export type RegionProjectsDataItemAttributesProjectTypeDataAttributes = {
   name?: string;
+  description?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: RegionProjectsDataItemAttributesProjectTypeDataAttributesCreatedBy;
@@ -4853,6 +4856,7 @@ export interface ProjectTypeResponse {
 
 export interface ProjectType {
   name: string;
+  description?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: ProjectTypeCreatedBy;
@@ -5071,6 +5075,7 @@ export interface ProjectTypeListResponse {
 
 export type ProjectTypeRequestData = {
   name: string;
+  description?: string;
 };
 
 export interface ProjectTypeRequest {
@@ -6206,6 +6211,7 @@ export type ProjectProjectTypeDataAttributesUpdatedBy = {
 
 export type ProjectProjectTypeDataAttributes = {
   name?: string;
+  description?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: ProjectProjectTypeDataAttributesCreatedBy;
@@ -7772,6 +7778,7 @@ export type PracticeCountryDataAttributesRegionDataAttributesProjectsDataItemAtt
 export type PracticeCountryDataAttributesRegionDataAttributesProjectsDataItemAttributesProjectTypeDataAttributes =
   {
     name?: string;
+    description?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: PracticeCountryDataAttributesRegionDataAttributesProjectsDataItemAttributesProjectTypeDataAttributesCreatedBy;
@@ -9852,6 +9859,7 @@ export type OrganizationCountryDataAttributesRegionDataAttributesProjectsDataIte
 export type OrganizationCountryDataAttributesRegionDataAttributesProjectsDataItemAttributesProjectTypeDataAttributes =
   {
     name?: string;
+    description?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: OrganizationCountryDataAttributesRegionDataAttributesProjectsDataItemAttributesProjectTypeDataAttributesCreatedBy;
@@ -10284,7 +10292,6 @@ export interface NotificationEmail {
   notification_email?: string;
   createdAt?: string;
   updatedAt?: string;
-  publishedAt?: string;
   createdBy?: NotificationEmailCreatedBy;
   updatedBy?: NotificationEmailUpdatedBy;
 }
@@ -12281,6 +12288,7 @@ export type LandUseTypePracticesPriorDataItemAttributesCountryDataAttributesRegi
 export type LandUseTypePracticesPriorDataItemAttributesCountryDataAttributesRegionDataAttributesProjectsDataItemAttributesProjectTypeDataAttributes =
   {
     name?: string;
+    description?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: LandUseTypePracticesPriorDataItemAttributesCountryDataAttributesRegionDataAttributesProjectsDataItemAttributesProjectTypeDataAttributesCreatedBy;
@@ -13801,6 +13809,7 @@ export type CountryRegionDataAttributesProjectsDataItemAttributesCountryOfCoordi
 
 export type CountryRegionDataAttributesProjectsDataItemAttributesProjectTypeDataAttributes = {
   name?: string;
+  description?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: CountryRegionDataAttributesProjectsDataItemAttributesProjectTypeDataAttributesCreatedBy;


### PR DESCRIPTION
This PR displays the number of results at the top of the sidebar in the Practices module.

## Acceptance criteria

- There is a way to see the total number of practices existing on the Practices module
  - If a filter is selected, the total number of filtered practices is displayed
  - Text: « Showing XXX practice(s). »
  - Design (for the Network module): https://www.figma.com/file/DBXFTLd6nFBmg6fFE6P2cX/ORCaSa-Design?type=design&node-id=451-55221&mode=design&t=3h7O8hlr2NOHEAjj-4

## Tracking

- [ORC-469](https://vizzuality.atlassian.net/browse/ORC-469) - Display the total number of matching practices
  - [ORC-470](https://vizzuality.atlassian.net/browse/ORC-470) - FE - Indicate the total number of matching practices

[ORC-469]: https://vizzuality.atlassian.net/browse/ORC-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ORC-470]: https://vizzuality.atlassian.net/browse/ORC-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ