### PR TITLE
Add confirm alert when form is dirty and user tries to leave

### DIFF
--- a/client/src/app/(modules)/network/(form)/new/organisation/page.tsx
+++ b/client/src/app/(modules)/network/(form)/new/organisation/page.tsx
@@ -13,9 +13,12 @@ import { z } from 'zod';
 
 import { cn } from '@/lib/classnames';
 
+import { useIsFormDirty } from '@/store/network';
+
 import { postOrganizations } from '@/types/generated/organization';
 import { OrganizationRequest, OrganizationRequestData } from '@/types/generated/strapi.schemas';
 
+import useBeforeUnloadDirtyForm from '@/hooks/navigation';
 import { useOrganizationGetFormFields } from '@/hooks/networks/forms';
 
 import InputComponent from '@/components/form/input-component';
@@ -34,6 +37,7 @@ import {
 export default function OrganisationForm() {
   const { organizationTypes, organizationThemes, countries, projects } =
     useOrganizationGetFormFields() || {};
+
   const OtherId = organizationTypes?.find((type) => type?.name === 'Other')?.id?.toString();
   const hasData = organizationTypes && organizationThemes && countries && projects;
   const [error, setError] = useState<AxiosError | undefined>();
@@ -195,9 +199,13 @@ export default function OrganisationForm() {
       ],
     },
   });
-  const { handleSubmit, watch } = form;
 
   const router = useRouter();
+
+  const [, setIsFormDirty] = useIsFormDirty();
+  useBeforeUnloadDirtyForm(form);
+
+  const { handleSubmit, watch } = form;
 
   if (!hasData || !fields) {
     return null;
@@ -220,6 +228,7 @@ export default function OrganisationForm() {
       data: normalizedData,
     } as unknown as OrganizationRequest)
       .then(() => {
+        setIsFormDirty(false);
         router.push(`/network/new/organisation/thank-you`);
       })
       .catch((err) => {

--- a/client/src/app/(modules)/network/(form)/new/project/page.tsx
+++ b/client/src/app/(modules)/network/(form)/new/project/page.tsx
@@ -15,9 +15,12 @@ import { z } from 'zod';
 
 import { cn } from '@/lib/classnames';
 
+import { useIsFormDirty } from '@/store/network';
+
 import { postProjects } from '@/types/generated/project';
 import { ProjectRequest, ProjectRequestData } from '@/types/generated/strapi.schemas';
 
+import useBeforeUnloadDirtyForm from '@/hooks/navigation';
 import { useProjectFormGetFields } from '@/hooks/networks/forms';
 
 import InputComponent from '@/components/form/input-component';
@@ -414,6 +417,9 @@ export default function ProjectForm() {
 
   const router = useRouter();
 
+  const [, setIsFormDirty] = useIsFormDirty();
+  useBeforeUnloadDirtyForm(form);
+
   if (!hasData || !fields) {
     return null;
   }
@@ -431,6 +437,7 @@ export default function ProjectForm() {
       data: normalizedData,
     } as unknown as ProjectRequest)
       .then(() => {
+        setIsFormDirty(false);
         router.push(`/network/new/project/thank-you`);
       })
       .catch((err) => {

--- a/client/src/app/(modules)/network/(main)/page.tsx
+++ b/client/src/app/(modules)/network/(main)/page.tsx
@@ -5,8 +5,6 @@ import { useEffect, useLayoutEffect, useRef } from 'react';
 import { Filter, Users2 } from 'lucide-react';
 import { usePreviousImmediate } from 'rooks';
 
-import env from '@/env.mjs';
-
 import { useSidebarScroll } from '@/store';
 
 import { useFiltersCount, useNetworkFilterSidebarOpen, useNetworkFilters } from '@/store/network';

--- a/client/src/hooks/navigation/index.ts
+++ b/client/src/hooks/navigation/index.ts
@@ -1,0 +1,104 @@
+// This is a solution to the problem of preventing the user from leaving the page when there are unsaved changes. It is a hook that listens to the beforeunload event and the click event on links. It also listens to the popstate event to detect when the user presses the back button. It is a workaround for the lack of a proper way to prevent the user from leaving the page in Next.js. The hook returns an object with a single method onBeforeUnload that should be called when the user tries to leave the page. If the method returns true, the user will be prompted with a confirmation message. If the user confirms, the page will be navigated to the new location.
+// Next 13 and 14 has removed the router events, so we have to use this workaround for now.
+// https:github.com/vercel/next.js/discussions/42016#discussioncomment-7668405
+
+import { useEffect } from 'react';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import { useIsFormDirty } from '@/store/network';
+
+const clickType = typeof document !== 'undefined' && document.ontouchstart ? 'touchstart' : 'click';
+
+interface GuardEventListener {
+  onBeforeUnload: () => boolean;
+}
+
+function usePageUnloadGuard(confirmMessage: string, callbackFunction: () => void) {
+  const router = useRouter();
+
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const listener: GuardEventListener = {
+    onBeforeUnload: () => false,
+  };
+
+  const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
+    listener.onBeforeUnload() && event.preventDefault();
+  };
+
+  const clickHandler = (event: MouseEvent | TouchEvent) => {
+    if ((event as MouseEvent).button || event.which !== 1) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+    const target = event.target as HTMLElement;
+    const anchor = target.closest('a');
+    if (!anchor) {
+      return;
+    }
+    const newPath = anchor.getAttribute('href');
+    if (newPath && newPath !== window.location.pathname && listener.onBeforeUnload()) {
+      event.preventDefault();
+      if (confirm(confirmMessage)) {
+        callbackFunction();
+        router.push(newPath);
+      }
+    }
+  };
+
+  const popStateHandler = (event: PopStateEvent) => {
+    if (event.state !== null) {
+      return;
+    }
+    if (listener.onBeforeUnload() && confirm(confirmMessage)) {
+      window.removeEventListener('popstate', popStateHandler);
+      history.back();
+      return;
+    }
+    // Returning to the fake history state
+    history.go(1);
+  };
+
+  useEffect(() => {
+    // Since 'popstate' fires at the end of the page swap, there is no option to
+    // cancel it. So we're adding artificial state and in case we got there,
+    // it means a user pressed back button.
+    // TODO: Check if it is safe to add these to deps so the effect will re-run with pathname and params change
+    history.pushState(null, '', pathname + searchParams.toString());
+    window.addEventListener('beforeunload', beforeUnloadHandler);
+    window.addEventListener('popstate', popStateHandler);
+    window.document.addEventListener(clickType, clickHandler, { capture: true });
+    return () => {
+      window.removeEventListener('popstate', popStateHandler);
+      window.removeEventListener('beforeunload', beforeUnloadHandler);
+      window.document.removeEventListener(clickType, clickHandler, { capture: true });
+    };
+  });
+
+  return listener;
+}
+
+const useBeforeUnloadDirtyForm = (form: { formState: { isDirty: boolean } } | undefined) => {
+  const [isFormDirty, setIsFormDirty] = useIsFormDirty();
+  const listener = usePageUnloadGuard(
+    `You are about to leave the form, and the information you've filled out so far will be deleted.`,
+    () => setIsFormDirty(false),
+  );
+
+  listener.onBeforeUnload = () => isFormDirty;
+
+  const isDirty = form?.formState.isDirty;
+  useEffect(() => {
+    if (isDirty) {
+      setIsFormDirty(isDirty);
+    }
+    return () => {
+      if (!isDirty) {
+        setIsFormDirty(false);
+      }
+    };
+  }, [isDirty, setIsFormDirty]);
+};
+
+export default useBeforeUnloadDirtyForm;

--- a/client/src/store/network.ts
+++ b/client/src/store/network.ts
@@ -61,8 +61,15 @@ const filtersAtom = atom<NetworkFilters>({
   interventionCountry: [],
   interventionArea: [],
 });
+
 export const useNetworkFilters = () => {
   return useAtom(filtersAtom);
+};
+
+const isFormDirtyAtom = atom<boolean>(false);
+
+export const useIsFormDirty = () => {
+  return useAtom(isFormDirtyAtom);
 };
 
 export const useNetworkOrganizationFilters = () => {

--- a/cms/config/sync/admin-role.strapi-author.json
+++ b/cms/config/sync/admin-role.strapi-author.json
@@ -5,18 +5,17 @@
   "permissions": [
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::area-of-intervention.area-of-intervention",
       "properties": {
         "fields": [
           "name"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
       "subject": "api::area-of-intervention.area-of-intervention",
       "properties": {
         "fields": [
@@ -25,11 +24,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::area-of-intervention.area-of-intervention",
       "properties": {
         "fields": [
@@ -38,22 +37,22 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::continent.continent",
       "properties": {
         "fields": [
           "name"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
       "subject": "api::continent.continent",
       "properties": {
         "fields": [
@@ -62,11 +61,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::continent.continent",
       "properties": {
         "fields": [
@@ -75,11 +74,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::country.country",
       "properties": {
         "fields": [
@@ -94,32 +93,11 @@
           "projects"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
-      "subject": "api::country.country",
-      "properties": {
-        "fields": [
-          "name",
-          "capital",
-          "code",
-          "fips",
-          "iso_2",
-          "iso_3",
-          "continent",
-          "region",
-          "projects"
-        ]
-      },
-      "conditions": [
-        "admin::is-creator"
-      ]
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::country.country",
       "properties": {
         "fields": [
@@ -136,39 +114,45 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
-    },
-    {
-      "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
-      "subject": "api::home-stat.home-stat",
-      "properties": {
-        "fields": [
-          "title",
-          "value",
-          "class"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
-      "subject": "api::home-stat.home-stat",
-      "properties": {
-        "fields": [
-          "title",
-          "value",
-          "class"
-        ]
-      },
-      "conditions": [
-        "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
+      "subject": "api::country.country",
+      "properties": {
+        "fields": [
+          "name",
+          "capital",
+          "code",
+          "fips",
+          "iso_2",
+          "iso_3",
+          "continent",
+          "region",
+          "projects"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "subject": "api::home-stat.home-stat",
+      "properties": {
+        "fields": [
+          "title",
+          "value",
+          "class"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
       "subject": "api::home-stat.home-stat",
       "properties": {
         "fields": [
@@ -179,37 +163,38 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
-    },
-    {
-      "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
-      "subject": "api::layer-group.layer-group",
-      "properties": {
-        "fields": [
-          "title",
-          "layers"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
-      "subject": "api::layer-group.layer-group",
-      "properties": {
-        "fields": [
-          "title",
-          "layers"
-        ]
-      },
-      "conditions": [
-        "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
+      "subject": "api::home-stat.home-stat",
+      "properties": {
+        "fields": [
+          "title",
+          "value",
+          "class"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "subject": "api::layer-group.layer-group",
+      "properties": {
+        "fields": [
+          "title",
+          "layers"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
       "subject": "api::layer-group.layer-group",
       "properties": {
         "fields": [
@@ -219,11 +204,25 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::layer-group.layer-group",
+      "properties": {
+        "fields": [
+          "title",
+          "layers"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::layer.layer",
       "properties": {
         "fields": [
@@ -235,11 +234,11 @@
           "interaction_config"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
       "subject": "api::layer.layer",
       "properties": {
         "fields": [
@@ -253,11 +252,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::layer.layer",
       "properties": {
         "fields": [
@@ -271,11 +270,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::organization-theme.organization-theme",
       "properties": {
         "fields": [
@@ -283,11 +282,11 @@
           "order"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
       "subject": "api::organization-theme.organization-theme",
       "properties": {
         "fields": [
@@ -297,11 +296,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::organization-theme.organization-theme",
       "properties": {
         "fields": [
@@ -311,11 +310,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::organization-type.organization-type",
       "properties": {
         "fields": [
@@ -323,11 +322,11 @@
           "order"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
       "subject": "api::organization-type.organization-type",
       "properties": {
         "fields": [
@@ -337,11 +336,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::organization-type.organization-type",
       "properties": {
         "fields": [
@@ -351,11 +350,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::organization.organization",
       "properties": {
         "fields": [
@@ -371,15 +370,15 @@
           "lead_projects",
           "partner_projects",
           "funded_projects",
-          "publication_status",
-          "user_email"
+          "user_email",
+          "publication_status"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
       "subject": "api::organization.organization",
       "properties": {
         "fields": [
@@ -395,17 +394,17 @@
           "lead_projects",
           "partner_projects",
           "funded_projects",
-          "publication_status",
-          "user_email"
+          "user_email",
+          "publication_status"
         ]
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::organization.organization",
       "properties": {
         "fields": [
@@ -421,17 +420,17 @@
           "lead_projects",
           "partner_projects",
           "funded_projects",
-          "publication_status",
-          "user_email"
+          "user_email",
+          "publication_status"
         ]
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::page.page",
       "properties": {
         "fields": [
@@ -443,11 +442,11 @@
           "external_url"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
       "subject": "api::page.page",
       "properties": {
         "fields": [
@@ -461,11 +460,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::page.page",
       "properties": {
         "fields": [
@@ -479,11 +478,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::practice.practice",
       "properties": {
         "fields": [
@@ -497,31 +496,11 @@
           "practice_intervention"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
-      "subject": "api::practice.practice",
-      "properties": {
-        "fields": [
-          "source_name",
-          "source_id",
-          "title",
-          "short_description",
-          "country",
-          "language",
-          "sync",
-          "practice_intervention"
-        ]
-      },
-      "conditions": [
-        "admin::is-creator"
-      ]
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::practice.practice",
       "properties": {
         "fields": [
@@ -537,35 +516,42 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
-    },
-    {
-      "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
-      "subject": "api::project-type.project-type",
-      "properties": {
-        "fields": [
-          "name"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
-      "subject": "api::project-type.project-type",
-      "properties": {
-        "fields": [
-          "name"
-        ]
-      },
-      "conditions": [
-        "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
+      "subject": "api::practice.practice",
+      "properties": {
+        "fields": [
+          "source_name",
+          "source_id",
+          "title",
+          "short_description",
+          "country",
+          "language",
+          "sync",
+          "practice_intervention"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "subject": "api::project-type.project-type",
+      "properties": {
+        "fields": [
+          "name"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
       "subject": "api::project-type.project-type",
       "properties": {
         "fields": [
@@ -574,11 +560,24 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::project-type.project-type",
+      "properties": {
+        "fields": [
+          "name"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::project.project",
       "properties": {
         "fields": [
@@ -600,18 +599,17 @@
           "main_area_of_intervention_other",
           "secondary_area_of_intervention",
           "third_area_of_intervention",
-          "sustainable_development_goals",
           "lead_partner",
           "partners",
           "funders",
           "publication_status"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
       "subject": "api::project.project",
       "properties": {
         "fields": [
@@ -633,7 +631,6 @@
           "main_area_of_intervention_other",
           "secondary_area_of_intervention",
           "third_area_of_intervention",
-          "sustainable_development_goals",
           "lead_partner",
           "partners",
           "funders",
@@ -642,11 +639,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::project.project",
       "properties": {
         "fields": [
@@ -668,7 +665,6 @@
           "main_area_of_intervention_other",
           "secondary_area_of_intervention",
           "third_area_of_intervention",
-          "sustainable_development_goals",
           "lead_partner",
           "partners",
           "funders",
@@ -677,11 +673,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::region.region",
       "properties": {
         "fields": [
@@ -689,11 +685,11 @@
           "projects"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
       "subject": "api::region.region",
       "properties": {
         "fields": [
@@ -703,11 +699,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::region.region",
       "properties": {
         "fields": [
@@ -717,22 +713,22 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
       "subject": "api::sustainable-dev-goal.sustainable-dev-goal",
       "properties": {
         "fields": [
           "name"
         ]
       },
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
       "subject": "api::sustainable-dev-goal.sustainable-dev-goal",
       "properties": {
         "fields": [
@@ -741,11 +737,11 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
       "subject": "api::sustainable-dev-goal.sustainable-dev-goal",
       "properties": {
         "fields": [
@@ -754,53 +750,54 @@
       },
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.copy-link",
-      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.create",
-      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.download",
-      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.assets.update",
-      "actionParameters": {},
       "subject": null,
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.configure-view",
-      "actionParameters": {},
       "subject": null,
       "properties": {},
-      "conditions": []
+      "conditions": [],
+      "actionParameters": {}
     },
     {
       "action": "plugin::upload.read",
-      "actionParameters": {},
       "subject": null,
       "properties": {},
       "conditions": [
         "admin::is-creator"
-      ]
+      ],
+      "actionParameters": {}
     }
   ]
 }

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##notification-email.notification-email.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##notification-email.notification-email.json
@@ -21,8 +21,8 @@
       },
       "notification_email": {
         "edit": {
-          "label": "Notification Email",
-          "description": "Email address(es) to be notified when a user suggests a new organization or project",
+          "label": "notification_email",
+          "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -93,6 +93,12 @@
       }
     },
     "layouts": {
+      "list": [
+        "id",
+        "notification_email",
+        "createdAt",
+        "updatedAt"
+      ],
       "edit": [
         [
           {
@@ -100,12 +106,6 @@
             "size": 6
           }
         ]
-      ],
-      "list": [
-        "id",
-        "notification_email",
-        "createdAt",
-        "updatedAt"
       ]
     },
     "uid": "api::notification-email.notification-email"


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/ORC-395?atlOrigin=eyJpIjoiMjdjYjY2MWNhZWNiNGZiZWJiYjlkYWU1ZTMxNGQ1MTgiLCJwIjoiaiJ9

This PR makes the user confirm if it leaves the page with an empty form. Due to the discontinued events on the router on Next and waiting for a upcoming solution I had to use a custom hook for the beforeUnload