### PR TITLE
Add pointer events to the popovers

### DIFF
--- a/client/src/app/(modules)/datasets/page.tsx
+++ b/client/src/app/(modules)/datasets/page.tsx
@@ -129,7 +129,7 @@ export default function DatasetsModule() {
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent
-                    className="w-[330px] overflow-y-auto rounded-none border border-gray-400 p-0 text-base shadow-none"
+                    className="pointer-events-auto w-[330px] overflow-y-auto rounded-none border border-gray-400 p-0 text-base shadow-none"
                     side="bottom"
                     sideOffset={-1}
                     align="start"
@@ -181,7 +181,7 @@ export default function DatasetsModule() {
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent
-                    className="w-[330px] overflow-y-auto rounded-none border border-gray-400 p-0 text-base shadow-none"
+                    className="pointer-events-auto w-[330px] overflow-y-auto rounded-none border border-gray-400 p-0 text-base shadow-none"
                     side="bottom"
                     sideOffset={-1}
                     align="start"

--- a/cms/config/sync/admin-role.strapi-editor.json
+++ b/cms/config/sync/admin-role.strapi-editor.json
@@ -404,50 +404,6 @@
       "actionParameters": {}
     },
     {
-      "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
-      "subject": "api::network-suggestion.network-suggestion",
-      "properties": {
-        "fields": [
-          "email_recipients"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
-      "subject": "api::network-suggestion.network-suggestion",
-      "properties": {
-        "fields": [
-          "email_recipients"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
-      "subject": "api::notification-email.notification-email",
-      "properties": {
-        "fields": [
-          "notification_email"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
-      "subject": "api::notification-email.notification-email",
-      "properties": {
-        "fields": [
-          "notification_email"
-        ]
-      },
-      "conditions": []
-    },
-    {
       "action": "plugin::content-manager.explorer.create",
       "subject": "api::organization-theme.organization-theme",
       "properties": {


### PR DESCRIPTION
This PR fixes the calendar inside popover problem for Chrome adding a point-events: auto on the popovers.

Missing: The dropdown is still not working on Firefox. There are some issues related to different versions of @radix-ui/react-dismissable-layer. I tried uninstalling the 'vault' component and using a resolutions field unsuccesfully 🤷 