### PR TITLE
Use a instead of next link for Scientific Evidence nav link

### DIFF
--- a/client/src/components/home/nav-bar.tsx
+++ b/client/src/components/home/nav-bar.tsx
@@ -32,7 +32,18 @@ const NavBar = () => (
     <nav className="hidden h-full items-center justify-center gap-10 font-serif text-base text-gray-500 lg:flex">
       {modules.map((module) => {
         const { href, name, color } = module;
-        return (
+        return 'external' in module && module.external ? (
+          <a
+            key={href}
+            href={href}
+            className={cn(
+              'box-border flex h-full items-center border-t-8 border-t-transparent',
+              moduleColors[color].hoverBorder,
+            )}
+          >
+            <div className="-mt-2 flex h-full items-center">{name}</div>
+          </a>
+        ) : (
           <Link
             key={href}
             href={href}

--- a/client/src/constants/modules.ts
+++ b/client/src/constants/modules.ts
@@ -31,6 +31,8 @@ export interface Module {
   slug: string;
   href: string;
   color: keyof typeof moduleColors;
+  // Links to an external website through redirect. Specific to Scientific Evidence module.
+  external?: boolean;
 }
 
 export const modules = [
@@ -45,6 +47,7 @@ export const modules = [
     slug: 'scientific-evidence',
     href: '/scientific-evidence',
     color: 'teal',
+    external: true,
   },
   {
     name: 'Practices',

--- a/cms/config/sync/user-role.public.json
+++ b/cms/config/sync/user-role.public.json
@@ -22,6 +22,12 @@
       "action": "api::country.country.findOne"
     },
     {
+      "action": "api::land-use-type.land-use-type.find"
+    },
+    {
+      "action": "api::land-use-type.land-use-type.findOne"
+    },
+    {
       "action": "api::layer-group.layer-group.find"
     },
     {
@@ -64,6 +70,12 @@
       "action": "api::page.page.findOne"
     },
     {
+      "action": "api::practice.practice.find"
+    },
+    {
+      "action": "api::practice.practice.findOne"
+    },
+    {
       "action": "api::project-type.project-type.find"
     },
     {
@@ -86,6 +98,18 @@
     },
     {
       "action": "api::region.region.findOne"
+    },
+    {
+      "action": "api::static-page.static-page.find"
+    },
+    {
+      "action": "api::static-page.static-page.findOne"
+    },
+    {
+      "action": "api::subintervention.subintervention.find"
+    },
+    {
+      "action": "api::subintervention.subintervention.findOne"
     },
     {
       "action": "api::sustainable-dev-goal.sustainable-dev-goal.find"


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/ORC-431?atlOrigin=eyJpIjoiYmI3NDc2ODI4MzRlNDEzY2FiMGI2YzM3ZTM5M2E5ZGIiLCJwIjoiaiJ9

This PR tries to address the following problem:

On firefox - home - click on the SE nav link - once you are on this page press the browser back button - After some seconds or hovering the links the browser navigates back to SE

We are using a 'a' tag instead of a link because of this issue: https://github.com/vercel/next.js/discussions/50958
