### PR TITLE
ORC-545  Display related projects in the practice view

### DIFF
--- a/client/src/app/(modules)/practices/(main)/(details)/field.tsx
+++ b/client/src/app/(modules)/practices/(main)/(details)/field.tsx
@@ -51,7 +51,7 @@ const Field = ({ label, value, url, hasEllipsis, logo, formatId }: FieldType) =>
               value?.[index] && (
                 <>
                   {index !== 0 ? <br /> : ''}
-                  <Link key={elemUrl} className="text-sm text-peach-700" href={`${elemUrl}`}>
+                  <Link key={elemUrl} className="text-sm text-brown-500" href={`${elemUrl}`}>
                     {value[index]}
                   </Link>
                 </>
@@ -72,7 +72,7 @@ const Field = ({ label, value, url, hasEllipsis, logo, formatId }: FieldType) =>
                     href={elemUrl}
                     target="_blank"
                     rel="noreferrer"
-                    className="text-sm text-peach-700"
+                    className="text-sm text-brown-500"
                   >
                     {value[index]}
                   </a>

--- a/client/src/app/(modules)/practices/(main)/(details)/field.tsx
+++ b/client/src/app/(modules)/practices/(main)/(details)/field.tsx
@@ -29,13 +29,13 @@ const Field = ({ label, value, url, hasEllipsis, logo, formatId }: FieldType) =>
   const renderSingleLink = (url: string, external = false) => {
     if (!external) {
       return (
-        <Link className="text-sm text-peach-700" href={`${url}`}>
+        <Link className="text-sm text-brown-500" href={`${url}`}>
           {value}
         </Link>
       );
     } else {
       return (
-        <a href={url} target="_blank" rel="noreferrer" className="text-sm text-peach-700">
+        <a href={url} target="_blank" rel="noreferrer" className="text-sm text-brown-500">
           {value}
         </a>
       );

--- a/client/src/app/(modules)/practices/(main)/(details)/field.tsx
+++ b/client/src/app/(modules)/practices/(main)/(details)/field.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/classnames';
 import { FormatProps, format as formatFunction } from '@/lib/utils/formats';
 
 import { useIsOverTwoLines } from '@/hooks/ui/utils';
+import Link from 'next/link';
 
 export type FieldType = {
   label: string;
@@ -25,32 +26,66 @@ const Field = ({ label, value, url, hasEllipsis, logo, formatId }: FieldType) =>
     setIsExpanded(!isExpanded);
   };
 
-  const renderLink = (url: string | string[]) =>
-    Array.isArray(url) ? (
-      <div>
-        {url.map(
-          (u, i) =>
-            value?.[i] && (
-              <>
-                {i !== 0 ? ', ' : ''}
-                <a
-                  key={u}
-                  href={u}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-sm text-brown-500"
-                >
-                  {formatId ? formatFunction({ id: formatId, value: value[i] }) : value[i]}
-                </a>
-              </>
-            ),
-        )}
-      </div>
-    ) : (
-      <a href={url} target="_blank" rel="noreferrer" className="text-sm text-peach-700">
-        {formatId ? formatFunction({ id: formatId, value }) : value}
-      </a>
-    );
+  const renderSingleLink = (url: string, external = false) => {
+    if (!external) {
+      return (
+        <Link className="text-sm text-peach-700" href={`${url}`}>
+          {value}
+        </Link>
+      );
+    } else {
+      return (
+        <a href={url} target="_blank" rel="noreferrer" className="text-sm text-peach-700">
+          {value}
+        </a>
+      );
+    }
+  };
+
+  const renderLinkArray = (url: Array<string>, external = false) => {
+    if (!external) {
+      return (
+        <div>
+          {url.map(
+            (elemUrl, index) =>
+              value?.[index] && (
+                <>
+                  {index !== 0 ? <br /> : ''}
+                  <Link key={elemUrl} className="text-sm text-peach-700" href={`${elemUrl}`}>
+                    {value[index]}
+                  </Link>
+                </>
+              ),
+          )}
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          {url.map(
+            (elemUrl, index) =>
+              value?.[index] && (
+                <>
+                  {index !== 0 ? <br /> : ''}
+                  <a
+                    key={elemUrl}
+                    href={elemUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-sm text-peach-700"
+                  >
+                    {value[index]}
+                  </a>
+                </>
+              ),
+          )}
+        </div>
+      );
+    }
+  };
+  const renderLink = (url: string | string[], external = false) => {
+    return Array.isArray(url) ? renderLinkArray(url, external) : renderSingleLink(url, external);
+  };
 
   const renderField = () => {
     if (logo) {

--- a/client/src/app/(modules)/practices/(main)/(details)/parsers.ts
+++ b/client/src/app/(modules)/practices/(main)/(details)/parsers.ts
@@ -14,6 +14,7 @@ export const getPracticeFields = (practice: Practice): FieldType[] => {
     publication_date: publicationDate,
     project_fund: projectName,
     institution_funding: institutionName,
+    projects,
   } = practice as TypedPractice;
 
   const fields = [];
@@ -44,6 +45,14 @@ export const getPracticeFields = (practice: Practice): FieldType[] => {
 
   if (projectName) {
     fields.push({ label: 'Initiative Name', value: projectName });
+  }
+
+  if (projects && projects?.data?.length) {
+    fields.push({
+      label: 'Project',
+      value: projects?.data?.map((project) => project.attributes?.name),
+      url: projects?.data?.map((project) => `/network/initiative/${project.id}`),
+    });
   }
 
   return fields;


### PR DESCRIPTION
Rendering links in field.tsx is done with the same logic as in [this PR](https://github.com/Orcasa-Platform/orcasa/pull/236) :
- if it has `external: true` param, those will be external link opening in new tab
- otherwise the link is internal and the Project details will be redirected to in the same tab