### PR TITLE
[Network] Only display approved organisations and projects on the map

### DIFF
--- a/client/src/hooks/networks/index.ts
+++ b/client/src/hooks/networks/index.ts
@@ -48,6 +48,7 @@ import {
   parseOrganization,
   parseProject,
   PROJECT_KEYS,
+  ACCEPTED_STATUS_FILTER,
 } from '@/hooks/networks/utils';
 
 import { sortByOrderAndName } from './utils';
@@ -106,15 +107,6 @@ export enum NetworkProjectStatusFilter {
   Finished,
   NotStarted,
 }
-
-const ACCEPTED_STATUS_FILTER = {
-  $or: [
-    {
-      publication_status: { $eq: 'accepted' },
-    },
-    { publication_status: { $null: true } },
-  ],
-};
 
 const getQueryFilters = (filters: NetworkFilters) => {
   const generalFilters =
@@ -379,6 +371,8 @@ const useGetNetworksRelations = ({ id, type }: Network) => {
   } = useFunction(
     id as number,
     {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       populate,
     },
     { query: { keepPreviousData: true } },

--- a/client/src/hooks/networks/utils.ts
+++ b/client/src/hooks/networks/utils.ts
@@ -46,38 +46,140 @@ export const PROJECT_KEYS: ProjectKey[] = ['lead_partner', 'partners', 'funders'
 
 type ProjectKey = 'lead_partner' | 'partners' | 'funders';
 
+export const ACCEPTED_STATUS_FILTER = {
+  publication_status: { $eq: 'accepted' },
+};
+
 export const getPopulateForFilters = (type: 'organization' | 'project' | undefined) =>
   type === 'organization'
-    ? String([
-        'country',
-        'lead_projects.country_of_coordination',
-        'lead_projects.lead_partner.country',
-        'lead_projects.partners.country',
-        'lead_projects.funders.country',
-        'partner_projects.country_of_coordination',
-        'partner_projects.lead_partner.country',
-        'partner_projects.partners.country',
-        'partner_projects.funders.country',
-        'funded_projects.country_of_coordination',
-        'funded_projects.lead_partner.country',
-        'funded_projects.partners.country',
-        'funded_projects.funders.country',
-      ])
-    : String([
-        'country_of_coordination',
-        'lead_partner.country',
-        'lead_partner.lead_projects.country_of_coordination',
-        'lead_partner.partner_projects.country_of_coordination',
-        'lead_partner.funded_projects.country_of_coordination',
-        'partners.country',
-        'partners.lead_project.country_of_coordination',
-        'partners.partner_projects.country_of_coordination',
-        'partners.funded_projects.country_of_coordination',
-        'funders.country',
-        'funders.lead_projects.country_of_coordination',
-        'funders.partner_projects.country_of_coordination',
-        'funders.funded_projects.country_of_coordination',
-      ]);
+    ? {
+        country: { populate: true },
+        lead_projects: {
+          populate: {
+            country_of_coordination: {
+              populate: true,
+            },
+            lead_partner: {
+              populate: ['country'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            partners: {
+              populate: ['country'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            funders: {
+              populate: ['country'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+          },
+          filters: ACCEPTED_STATUS_FILTER,
+        },
+        partner_projects: {
+          populate: {
+            country_of_coordination: {
+              populate: true,
+            },
+            lead_partner: {
+              populate: ['country'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            partners: {
+              populate: ['country'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            funders: {
+              populate: ['country'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+          },
+          filters: ACCEPTED_STATUS_FILTER,
+        },
+        funded_projects: {
+          populate: {
+            country_of_coordination: {
+              populate: true,
+            },
+            lead_partner: {
+              populate: ['country'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            partners: {
+              populate: ['country'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            funders: {
+              populate: ['country'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+          },
+          filters: ACCEPTED_STATUS_FILTER,
+        },
+      }
+    : {
+        country_of_coordination: {
+          populate: true,
+        },
+        lead_partner: {
+          populate: {
+            country: {
+              populate: true,
+            },
+            lead_projects: {
+              populate: ['country_of_coordination'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            partner_projects: {
+              populate: ['country_of_coordination'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            funded_projects: {
+              populate: ['country_of_coordination'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+          },
+          filters: ACCEPTED_STATUS_FILTER,
+        },
+        partners: {
+          populate: {
+            country: {
+              populate: true,
+            },
+            lead_projects: {
+              populate: ['country_of_coordination'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            partner_projects: {
+              populate: ['country_of_coordination'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            funded_projects: {
+              populate: ['country_of_coordination'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+          },
+          filters: ACCEPTED_STATUS_FILTER,
+        },
+        funders: {
+          populate: {
+            country: {
+              populate: true,
+            },
+            lead_projects: {
+              populate: ['country_of_coordination'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            partner_projects: {
+              populate: ['country_of_coordination'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+            funded_projects: {
+              populate: ['country_of_coordination'],
+              filters: ACCEPTED_STATUS_FILTER,
+            },
+          },
+          filters: ACCEPTED_STATUS_FILTER,
+        },
+      };
 
 // Get country data from the organization or project
 export const getCountryData = (


### PR DESCRIPTION
This PR fixes an issue where the Network's map could display non-approved organisations and projects.

## Reproduction steps

1. Open the Network module (staging API)
2. Go to the detail view of “ORCaSa”
3. Zoom in on France

Make sure that:

- The organisation “National Research Agency - ANR” and the project “FREACS” are not displayed on the map.
- The map displays the same amount of organisations and projects as the diagram in the sidebar.

## Tracking

[ORC-595](https://vizzuality.atlassian.net/browse/ORC-595)

[ORC-595]: https://vizzuality.atlassian.net/browse/ORC-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ