### PR TITLE
[Network] Fix visual glitches in the diagram

### DIFF
--- a/client/src/components/network-diagram/index.tsx
+++ b/client/src/components/network-diagram/index.tsx
@@ -68,7 +68,7 @@ const NetworkDiagram = ({
             type={type}
             hasChildren={networks?.length > 0}
             hasDot={networks?.length > 0}
-            className="z-40"
+            style={{ zIndex: 1000 + networks.length }}
           />
           {
             [...networks]
@@ -87,7 +87,7 @@ const NetworkDiagram = ({
                     key={network.id}
                     className="relative ml-14"
                     // We use the z-index to make sure each path is above the following one
-                    style={{ zIndex: 30 + childIndex }}
+                    style={{ zIndex: 1000 + childIndex }}
                   >
                     <Item
                       key={network.id}
@@ -99,7 +99,7 @@ const NetworkDiagram = ({
                       opened={openCollapsibles.includes(network.id)}
                       heightIndex={getIndex(childIndex)}
                       hasChildren={network?.children?.length > 0}
-                      className="z-30"
+                      style={{ zIndex: 1000 + childIndex }}
                     />
                     <CollapsibleContent className="ml-14">
                       {
@@ -117,7 +117,10 @@ const NetworkDiagram = ({
                                   id={child?.id}
                                   heightIndex={grandChildIndex}
                                   hasChildren={false}
-                                  style={{ zIndex: 20 + +grandChildIndex }}
+                                  style={{
+                                    zIndex:
+                                      1000 + childIndex + grandChildIndex - network.children.length,
+                                  }}
                                 />
                               ),
                           )

--- a/client/src/components/network-diagram/item.tsx
+++ b/client/src/components/network-diagram/item.tsx
@@ -136,7 +136,7 @@ const Item = ({
   const canExpandWithChildren = typeof onToggle !== 'undefined' && hasChildren;
   const canExpandWithoutChildren = typeof onToggle !== 'undefined' && !hasChildren;
   return (
-    <div className={cn('relative z-30 -mt-6 w-full', className)} style={style}>
+    <div className={cn('relative -mt-6 w-full', className)} style={style}>
       {/* PATH */}
       {!isFirstNode && typeof heightIndex !== 'undefined' && (
         <Path
@@ -154,14 +154,11 @@ const Item = ({
       )}
       {/* CONTENT */}
       <div
-        className={cn(
-          'z-30 mt-10 flex h-20 w-fit min-w-full items-center justify-between gap-6 p-4',
-          {
-            'border border-slate-700': isFirstNode || opened,
-            'bg-blue-50': type === 'organization',
-            'bg-peach-50': type === 'project',
-          },
-        )}
+        className={cn('mt-10 flex h-20 w-fit min-w-full items-center justify-between gap-6 p-4', {
+          'border border-slate-700': isFirstNode || opened,
+          'bg-blue-50': type === 'organization',
+          'bg-peach-50': type === 'project',
+        })}
       >
         <Link
           className={cn('text-sm text-slate-700', {


### PR DESCRIPTION
This PR fixes an issue where visual glitches would appear in the Network diagram due to z-index positioning.

## Reproduction steps

1. Open the Network module (demo API)
2. Open the “ORCaSa” initiative

Make sure that the the links are displayed below the cards (both at the top level and sub-level).

## Tracking

[ORC-584](https://vizzuality.atlassian.net/browse/ORC-584)

[ORC-584]: https://vizzuality.atlassian.net/browse/ORC-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ