### PR TITLE
Address an issue where some active filters may not be displayed

### DIFF
--- a/client/src/hooks/datasets/index.ts
+++ b/client/src/hooks/datasets/index.ts
@@ -115,7 +115,7 @@ export const useDatasetsActiveFilters = () => {
               };
             }
           })
-          .filter((filter) => !!filter?.value) as {
+          .filter((filter) => filter?.value !== undefined && filter?.value !== null) as {
           filter: string;
           label: string;
           value: string;

--- a/client/src/hooks/networks/index.ts
+++ b/client/src/hooks/networks/index.ts
@@ -1126,7 +1126,11 @@ export const useNetworkActiveFilters = () => {
             };
           }
         })
-        .filter((filter) => !!filter?.value) as { filter: string; label: string; value: number }[];
+        .filter((filter) => filter?.value !== undefined && filter?.value !== null) as {
+        filter: string;
+        label: string;
+        value: number;
+      }[];
     })
     .flat();
 };

--- a/client/src/hooks/practices/index.ts
+++ b/client/src/hooks/practices/index.ts
@@ -597,7 +597,7 @@ export const usePracticesActiveFilters = () => {
               };
             }
           })
-          .filter((filter) => !!filter?.value) as {
+          .filter((filter) => filter?.value !== undefined && filter?.value !== null) as {
           filter: string;
           label: string;
           value: number;


### PR DESCRIPTION
This PR addresses an issue where some active filters may not be displayed at the top of the list in the Practices, Network and Datasets modules.

## Acceptance criteria

### Steps to reproduce

1. Open the Network module (redesign branch)
2. Filter by “Initiative status” by picking the “Active” value

### Result

Below the search bar the “Active” tag (indicating that the filter is active) does not appear.

### Expected result

Below the search bar the “Active” tag is displayed.

## Tracking

[ORC-613](https://vizzuality.atlassian.net/browse/ORC-613)