### PR TITLE
[Geospatial data] Display attributions for the layers on the map

### DIFF
--- a/client/src/containers/map/attributions/index.tsx
+++ b/client/src/containers/map/attributions/index.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from 'react';
+
+import { AttributionControl } from 'react-map-gl';
+
+import { usePathname } from 'next/navigation';
+
+import { useLayers } from '@/store';
+
+import { useGetLayers } from '@/types/generated/layer';
+
+const Attributions = () => {
+  const pathname = usePathname();
+  const isGeospatialDataPage = pathname?.includes('geospatial-data');
+
+  const [layers] = useLayers();
+
+  const { data } = useGetLayers(
+    {
+      fields: ['id', 'source'],
+      filters: {
+        id: {
+          $in: layers,
+        },
+      },
+      sort: 'source',
+    },
+    {
+      query: {
+        enabled: isGeospatialDataPage && layers.length > 0,
+      },
+    },
+  );
+
+  const attributions = useMemo(() => {
+    if (!!data) {
+      const sources = Array.from(
+        new Set(data.data?.map(({ attributes }) => attributes?.source)) ?? [],
+      );
+
+      return sources.reduce((res, name, index) => {
+        const isFirst = index === 0;
+        const isLast = index + 1 === sources.length;
+
+        let content = name;
+        if (name === 'RW' || name === 'ResourceWatch' || name === 'Resource Watch') {
+          content = `<a href="https://resourcewatch.org/" rel="noopener noreferrer">${name}</a>`;
+        } else if (
+          name === 'GFW' ||
+          name === 'GlobalForestWatch' ||
+          name === 'Global Forest Watch'
+        ) {
+          content = `<a href="https://www.globalforestwatch.org/" rel="noopener noreferrer">${name}</a>`;
+        }
+
+        if (isFirst) {
+          return `${res}${content}`;
+        } else {
+          if (!isLast) {
+            return `${res}, ${content}`;
+          } else {
+            return `${res} and ${content}`;
+          }
+        }
+      }, 'Powered by ');
+    }
+
+    return '';
+  }, [data]);
+
+  return <AttributionControl key={attributions} customAttribution={attributions} />;
+};
+
+export default Attributions;

--- a/client/src/containers/map/attributions/index.tsx
+++ b/client/src/containers/map/attributions/index.tsx
@@ -43,13 +43,13 @@ const Attributions = () => {
 
         let content = name;
         if (name === 'RW' || name === 'ResourceWatch' || name === 'Resource Watch') {
-          content = `<a href="https://resourcewatch.org/" rel="noopener noreferrer">${name}</a>`;
+          content = `<a href="https://resourcewatch.org/" rel="noopener noreferrer" target="_blank">${name}</a>`;
         } else if (
           name === 'GFW' ||
           name === 'GlobalForestWatch' ||
           name === 'Global Forest Watch'
         ) {
-          content = `<a href="https://www.globalforestwatch.org/" rel="noopener noreferrer">${name}</a>`;
+          content = `<a href="https://www.globalforestwatch.org/" rel="noopener noreferrer" target="_blank">${name}</a>`;
         }
 
         if (isFirst) {

--- a/client/src/containers/map/index.tsx
+++ b/client/src/containers/map/index.tsx
@@ -22,6 +22,7 @@ import { Bbox } from '@/types/map';
 
 import { useMapPadding } from '@/hooks/map';
 
+import Attributions from '@/containers/map/attributions';
 import Popup from '@/containers/map/popup';
 import MapSettings from '@/containers/map/settings';
 import MapSettingsManager from '@/containers/map/settings/manager';
@@ -219,6 +220,7 @@ export default function MapContainer() {
         interactiveLayerIds={layersInteractiveIds.map((id) => id.toString())}
         onClick={handleMapClick}
         onMapViewStateChange={handleMapViewStateChange}
+        attributionControl={false}
       >
         {() => (
           <>
@@ -235,6 +237,8 @@ export default function MapContainer() {
             <MapSettingsManager />
 
             <Legend />
+
+            <Attributions />
           </>
         )}
       </Map>

--- a/client/src/containers/map/legend/index.tsx
+++ b/client/src/containers/map/legend/index.tsx
@@ -128,7 +128,7 @@ const MapLegends = ({ className = '' }) => {
 
   return (
     <div
-      className={cn('absolute bottom-8 right-6 z-10 max-w-xs', {
+      className={cn('absolute bottom-9 right-6 z-10 max-w-xs min-[1810px]:bottom-8', {
         'w-full': !isPracticesPage && !isNetworkPage,
       })}
     >

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -98,10 +98,6 @@
   @apply !px-1 !py-px font-sans font-medium text-white !bg-gray-800/80 text-2xs;
 }
 
-.mapboxgl-ctrl-attrib-inner {
-  @apply !line-clamp-1;
-}
-
 .mapboxgl-ctrl-attrib.mapboxgl-compact {
   @apply !rounded-md;
 }

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -81,7 +81,7 @@
 
 /* Overrides */
 
-/* Maplibre */
+/* Mapbox */
 .mapboxgl-popup-content {
   @apply !rounded-lg !p-0;
 }
@@ -91,11 +91,15 @@
 }
 
 .mapboxgl-ctrl-bottom-right {
-  @apply max-w-[65%];
+  @apply max-w-[calc(100%_-_min(45%,_580px))];
 }
 
 .mapboxgl-ctrl-attrib {
   @apply !px-1 !py-px font-sans font-medium text-white !bg-gray-800/80 text-2xs;
+}
+
+.mapboxgl-ctrl-attrib-inner {
+  @apply !line-clamp-1;
 }
 
 .mapboxgl-ctrl-attrib.mapboxgl-compact {


### PR DESCRIPTION
This PR displays the sources of the active layers as attributions on the map.

## Acceptance criteria

- At the bottom of the module, there is the following text: “Powered by:” followed by the list of sources of the active layers
  - The Resource Watch and Global Forest Watch sources have a link to their homepage

## Tracking

[ORC-615](https://vizzuality.atlassian.net/browse/ORC-615)

[ORC-615]: https://vizzuality.atlassian.net/browse/ORC-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ