### PR TITLE
[Practices] Address an issue where practices for which the main intervention is “None” would be excluded from the default view

### DIFF
--- a/client/src/hooks/practices/index.ts
+++ b/client/src/hooks/practices/index.ts
@@ -121,7 +121,7 @@ const getQueryFilters = (filters: PracticesFilters) => {
     ...(filters.mainIntervention
       ? [{ practice_intervention: { $eq: filters.mainIntervention } }]
       : []),
-    ...(filters.mainIntervention === 'Management' && filters.subInterventions
+    ...(filters.mainIntervention === 'Management' && filters.subInterventions.length > 0
       ? [
           {
             $or: filters.subInterventions.map((id) => ({
@@ -134,7 +134,7 @@ const getQueryFilters = (filters: PracticesFilters) => {
           },
         ]
       : []),
-    ...(filters.mainIntervention === 'Land Use Change' && filters.priorLandUseTypes
+    ...(filters.mainIntervention === 'Land Use Change' && filters.priorLandUseTypes.length > 0
       ? [
           {
             $or: filters.priorLandUseTypes.map((id) => ({
@@ -147,7 +147,7 @@ const getQueryFilters = (filters: PracticesFilters) => {
           },
         ]
       : []),
-    ...(filters.mainIntervention && filters.landUseTypes
+    ...(filters.mainIntervention && filters.landUseTypes.length > 0
       ? [
           {
             $or: filters.landUseTypes.map((id) => ({
@@ -163,7 +163,7 @@ const getQueryFilters = (filters: PracticesFilters) => {
     // Main intervention is not selected:
     // We have to select all practices that have the selected land use types as land use types or prior land use types
     // and also prior land use types in the case of Land Use Change Management
-    ...(!filters.mainIntervention && filters.landUseTypes
+    ...(!filters.mainIntervention && filters.landUseTypes.length > 0
       ? [
           {
             $or: [


### PR DESCRIPTION
This PR fixes an issue where filters would be applied by default on the Practices module, making the total count of practices different from the one shown on the homepage.

This PR complements https://github.com/Orcasa-Platform/orcasa/pull/288 after which the main test case was still not passing.

## Testing instructions

### Steps to reproduce

1. Open the Practices module

### Result

The query to fetch the practices filter them by main intervention: practice_intervention = Management OR practice_intervention = Land Use Change. This excludes practices for which there is no main intervention. 

### Expected result

The query to fetch the practices does not filter by main intervention, which means that practices without one are shown by default.

## Tracking

[ORC-628](https://vizzuality.atlassian.net/browse/ORC-628)

[ORC-628]: https://vizzuality.atlassian.net/browse/ORC-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ