### PR TITLE
[Network] Remove the ID from the suggestion email's title

### DIFF
--- a/client/src/app/(modules)/network/(main)/(details)/initiative/[id]/page.tsx
+++ b/client/src/app/(modules)/network/(main)/(details)/initiative/[id]/page.tsx
@@ -109,7 +109,7 @@ export default async function ProjectDetails({ params }: ProjectDetailsProps) {
         ))}
       </div>
       <div className="flex justify-end gap-4 border-t border-gray-600 pt-6">
-        <SuggestButton id={id} data={project} label="initiative" />
+        <SuggestButton data={project} label="initiative" />
 
         <Button asChild variant="outline-dark" size="sm" disabled={!website}>
           <a href={makeGlobalLink(website)} target="_blank" rel="noreferrer">

--- a/client/src/app/(modules)/network/(main)/(details)/organization/[id]/page.tsx
+++ b/client/src/app/(modules)/network/(main)/(details)/organization/[id]/page.tsx
@@ -65,7 +65,7 @@ export default async function OrganizationDetails({ params }: OrganizationDetail
         )}
       </div>
       <div className="flex justify-end gap-4 border-t border-gray-600 pt-6">
-        <SuggestButton id={id} data={organization} label="organisation" />
+        <SuggestButton data={organization} label="organisation" />
         <Button asChild variant="outline-dark" size="sm" disabled={!url}>
           <a href={makeGlobalLink(url)} target="_blank" rel="noreferrer">
             <ExternalLink className="mr-2 h-4 w-4" />

--- a/client/src/app/(modules)/network/(main)/(details)/suggest-button.tsx
+++ b/client/src/app/(modules)/network/(main)/(details)/suggest-button.tsx
@@ -8,11 +8,9 @@ import { Button } from '@/components/ui/button';
 
 const SuggestButton = ({
   data,
-  id,
   label,
 }: {
   data: { name: string };
-  id: number;
   label: 'initiative' | 'organisation';
 }) => {
   const networkEmails = useGetNetworkSuggestion();
@@ -24,7 +22,7 @@ const SuggestButton = ({
     <Button variant="outline-dark" size="sm" asChild>
       <a
         href={`mailto:${emails.join(',')}?subject=${encodeURIComponent(
-          `Impact4Soil - Network - Change suggestion for ${label} "${data.name}", ID: ${id}`,
+          `Impact4Soil - Network - Change suggestion for ${label} "${data.name}"`,
         )}&body=${encodeURIComponent(
           `Kindly provide comprehensive details below regarding the changes you'd like to suggest. Include your name, your affiliated organisation, and an email address for potential contact. Thank you for assisting us in keeping the Soil Carbon Network up-to-date! Sincerely, The Impact4Soil Team.`,
         )}`}


### PR DESCRIPTION
This PR removes the ID from the title of the email that is sent when a user suggests changes to an organisation or initiative.

## Acceptance criteria

- The email template to suggest changes to an organisation/initiative doesn’t contain the ID of the entity in the title
  - « Impact4Soil - Network - Change suggestion for [organisation|project] "[NAME]"~~, ID: [ID]~~ »

## Tracking

[ORC-512](https://vizzuality.atlassian.net/browse/ORC-512)


[ORC-512]: https://vizzuality.atlassian.net/browse/ORC-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ