### PR TITLE
[Network] Do not perform the keyword search in the main description field

### DIFF
--- a/client/src/hooks/networks/index.ts
+++ b/client/src/hooks/networks/index.ts
@@ -124,11 +124,6 @@ const getQueryFilters = (filters: NetworkFilters) => {
                   $containsi: filters.search,
                 },
               },
-              {
-                description: {
-                  $containsi: filters.search,
-                },
-              },
             ],
           },
         ]


### PR DESCRIPTION
This PR changes the logic of the keyword search so that it is only performed using the title and short description of the organisations and initiatives.

## Acceptance criteria

- There is a way to search organisations and initiatives by keyword
  - Match names which include the keywords (exact same characters but case insensitive)
  - Match short descriptions which include the keywords (exact same characters but case insensitive)
  - ~~Match descriptions which include the keywords (exact same characters but case insensitive)~~

## Tracking

[ORC-585](https://vizzuality.atlassian.net/browse/ORC-585)

[ORC-585]: https://vizzuality.atlassian.net/browse/ORC-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ