### PR TITLE
[Practices] Add a description to the “Implementation decade” field

### DIFF
--- a/client/src/app/(modules)/practices/[id]/field.tsx
+++ b/client/src/app/(modules)/practices/[id]/field.tsx
@@ -6,14 +6,25 @@ import { useRef, useState } from 'react';
 import Link from 'next/link';
 
 import { ExternalLink } from 'lucide-react';
+import InfoButton from 'public/images/info-dark.svg';
 
 import { cn } from '@/lib/classnames';
 import { FormatProps, format as formatFunction } from '@/lib/utils/formats';
 
 import { useIsOverTwoLines } from '@/hooks/ui/utils';
 
+import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
 export type FieldType = {
   label: string;
+  description?: string;
   value: string | (string | undefined)[] | undefined;
   url?: string | string[];
   hasEllipsis?: boolean;
@@ -46,13 +57,16 @@ const FieldLink = ({
     </Link>
   );
 
-const Field = ({ label, value, url, hasEllipsis, logo, formatId }: FieldType) => {
+const Field = ({ label, value, description, url, hasEllipsis, logo, formatId }: FieldType) => {
   const ref = useRef<HTMLDivElement>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const isOverTwoLines = useIsOverTwoLines(ref, hasEllipsis);
   const toggleExpanded = () => {
     setIsExpanded(!isExpanded);
   };
+
+  const [openInfo, setInfoOpen] = useState(false);
+  const handleInfoClick = () => setInfoOpen((prevOpen) => !prevOpen);
 
   const renderLink = (url: string | string[], external = false) => {
     return Array.isArray(url) ? (
@@ -85,23 +99,42 @@ const Field = ({ label, value, url, hasEllipsis, logo, formatId }: FieldType) =>
     return url ? (
       renderLink(url)
     ) : (
-      <div>
-        <div
-          ref={ref}
-          className={cn('text-sm text-gray-200', {
-            'line-clamp-2': !isExpanded && isOverTwoLines,
-          })}
-        >
-          {formatId ? formatFunction({ id: formatId, value }) : value}
+      <>
+        <div className="flex items-center space-x-2">
+          <div
+            ref={ref}
+            className={cn('text-sm text-gray-200', {
+              'line-clamp-2': !isExpanded && isOverTwoLines,
+            })}
+          >
+            {formatId ? formatFunction({ id: formatId, value }) : value}
+          </div>
+          {description && (
+            <TooltipProvider>
+              <Tooltip delayDuration={0} open={openInfo} onOpenChange={setInfoOpen}>
+                <TooltipTrigger asChild onClick={handleInfoClick}>
+                  <Button type="button" size="auto" variant="icon">
+                    <span className="sr-only">Info</span>
+                    <InfoButton className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent variant="dark" className="max-w-[293px] text-sm leading-7">
+                  {description}
+                  <TooltipArrow variant="dark" className="-ml-3" />
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
         </div>
         {isOverTwoLines && (
           <button onClick={toggleExpanded} className="text-sm font-semibold">
             {isExpanded ? 'Show less' : 'Show more'}
           </button>
         )}
-      </div>
+      </>
     );
   };
+
   return (
     <div className="flex gap-6">
       <div className="w-[128px] min-w-[128px] text-sm lg:w-[224px] lg:min-w-[224px]">{label}</div>

--- a/client/src/app/(modules)/practices/[id]/parsers.ts
+++ b/client/src/app/(modules)/practices/[id]/parsers.ts
@@ -105,6 +105,7 @@ export const getPracticeImplementationFields = (practice: Practice): FieldType[]
     fields.push({
       label: 'Implementation decade',
       value: implementationDecade,
+      description: 'Effective from the date of publication',
     });
   }
 


### PR DESCRIPTION
This PR adds a description to the “Implementation decade” field displayed in the detailed view of some practices.

## Acceptance criteria

- On the detail view of a practice, there is a way to explain to the user what’s the reference date for the implementation decade
  - 🧑‍💻 After the implementation decade value, an info button is displayed with the following tooltip content: “Effective from the date of publication”

## Tracking

[ORC-607](https://vizzuality.atlassian.net/browse/ORC-607)

[ORC-607]: https://vizzuality.atlassian.net/browse/ORC-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ