### PR TITLE
[Network] Sort the network diagram alphabetically (in addition to by relation)

### DIFF
--- a/client/src/hooks/networks/index.ts
+++ b/client/src/hooks/networks/index.ts
@@ -592,57 +592,118 @@ export const useNetworkDiagram = ({
 }) => {
   const useFunction = type === 'organization' ? useGetOrganizations : useGetProjects;
   const filterPublicationStatus = { filters: { publication_status: { $eq: 'accepted' } } };
+  const sort = { sort: 'name' };
   const populate =
     type === 'organization'
       ? {
           lead_projects: {
             ...filterPublicationStatus,
+            ...sort,
             populate: {
-              lead_partner: filterPublicationStatus,
-              partners: filterPublicationStatus,
-              funders: filterPublicationStatus,
+              lead_partner: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              partners: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              funders: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
             },
           },
           partner_projects: {
             ...filterPublicationStatus,
+            ...sort,
             populate: {
-              lead_partner: filterPublicationStatus,
-              partners: filterPublicationStatus,
-              funders: filterPublicationStatus,
+              lead_partner: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              partners: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              funders: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
             },
           },
           funded_projects: {
             ...filterPublicationStatus,
+            ...sort,
             populate: {
-              lead_partner: filterPublicationStatus,
-              partners: filterPublicationStatus,
-              funders: filterPublicationStatus,
+              lead_partner: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              partners: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              funders: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
             },
           },
         }
       : {
           lead_partner: {
             ...filterPublicationStatus,
+            ...sort,
             populate: {
-              lead_projects: filterPublicationStatus,
-              partner_projects: filterPublicationStatus,
-              funded_projects: filterPublicationStatus,
+              lead_projects: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              partner_projects: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              funded_projects: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
             },
           },
           partners: {
             ...filterPublicationStatus,
+            ...sort,
             populate: {
-              lead_projects: filterPublicationStatus,
-              partner_projects: filterPublicationStatus,
-              funded_projects: filterPublicationStatus,
+              lead_projects: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              partner_projects: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              funded_projects: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
             },
           },
           funders: {
             ...filterPublicationStatus,
+            ...sort,
             populate: {
-              lead_projects: filterPublicationStatus,
-              partner_projects: filterPublicationStatus,
-              funded_projects: filterPublicationStatus,
+              lead_projects: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              partner_projects: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
+              funded_projects: {
+                ...filterPublicationStatus,
+                ...sort,
+              },
             },
           },
         };


### PR DESCRIPTION
This PR adds an extra sorting criteria for the network diagram: within a (sorted) relation type, the organisations and initiatives are now sorted alphabetically.

## Acceptance criteria

- In the network diagram, the second and third level of organisations/initiatives are sorted based on two criteria:
  - Their relation to their parent: Coordinator (first), Partner, Funder (last)
  - Their alphabetical order ascending: A → Z

## Tracking

- [ORC-605](https://vizzuality.atlassian.net/browse/ORC-605) - Improvements to the network diagram
  - [ORC-631](https://vizzuality.atlassian.net/browse/ORC-631) - FE - Update the sorting order of the organisations/initiatives in the network diagram