### PR TITLE
[Network] Improvements to the initiative detailed view

### DIFF
--- a/client/src/app/(modules)/network/(main)/(details)/parsers.ts
+++ b/client/src/app/(modules)/network/(main)/(details)/parsers.ts
@@ -81,7 +81,10 @@ export const getProjectFields = (
     });
   }
 
-  if (hasData(fields.project_coordinator_email) || hasData(project.project_coordinator_website)) {
+  if (
+    hasData(fields.project_coordinator_email) ||
+    ('project_coordinator_email' in fields && hasData(project.project_coordinator_website))
+  ) {
     const makeGlobalLink = (link: string) =>
       link.startsWith('http://') || link.startsWith('https://')
         ? link

--- a/client/src/components/map/networks-popup/index.tsx
+++ b/client/src/components/map/networks-popup/index.tsx
@@ -31,25 +31,53 @@ type NetworksPopupProps = {
   parentName?: string | undefined;
 };
 
-const networkDetailSentencePart = (parentType: Type, parentName: string, type: Type) => {
-  if (!parentType) return null;
+const networkDetailSentencePart = (
+  parentType: Type | undefined,
+  parentName: string | undefined,
+  type: Type,
+  countryName: string,
+) => {
   const parentSpan = <span className="font-semibold">{parentName}</span>;
-  if (parentType === 'project')
+
+  // Used on the detailed view
+  if (parentType === 'organization') {
     return (
-      <span>
-        {type === 'project' ? <> related to {parentSpan}</> : <> participating in {parentSpan}</>}
-      </span>
+      <>
+        <span>{type === 'project' ? 'Initiatives coordinated in ' : 'Organisations from '}</span>
+        <span className="font-semibold">{countryName}</span>
+        <span>
+          {type === 'project' ? (
+            <> in which {parentSpan} participates</>
+          ) : (
+            <> related to {parentSpan}</>
+          )}
+        </span>
+      </>
     );
-  if (parentType === 'organization')
+  }
+
+  // Used on the detailed view
+  if (parentType === 'project') {
+    if (type === 'project') {
+      return <span>Selected initiative</span>;
+    }
+
     return (
-      <span>
-        {type === 'project' ? (
-          <> in which {parentSpan} participates</>
-        ) : (
-          <> related to {parentSpan}</>
-        )}
-      </span>
+      <>
+        <span>Organisations from </span>
+        <span className="font-semibold">{countryName}</span>
+        <span> participating in {parentSpan}</span>
+      </>
     );
+  }
+
+  // Used on the global view
+  return (
+    <>
+      <span>{type === 'project' ? 'Initiatives coordinated in ' : 'Organisations from '}</span>
+      <span className="font-semibold">{countryName}</span>
+    </>
+  );
 };
 
 const NetworksPopup = ({ popup, setPopup, parentType, parentName }: NetworksPopupProps) => {
@@ -88,9 +116,7 @@ const NetworksPopup = ({ popup, setPopup, parentType, parentName }: NetworksPopu
           <X className="h-4 w-4 text-gray-500" />
         </Button>
         <header className="pb-6 pr-9 text-lg text-slate-700">
-          <span>{type === 'project' ? 'Initiatives coordinated in ' : 'Organisations from '}</span>
-          <span className="font-semibold">{countryName}</span>
-          {parentType && parentName && networkDetailSentencePart(parentType, parentName, type)}
+          {networkDetailSentencePart(parentType, parentName, type, countryName)}
         </header>
         <ul className="flex max-h-[232px] list-inside list-disc flex-col items-start justify-start gap-2 overflow-y-auto">
           {networks.map(({ id, name, type }) => (


### PR DESCRIPTION
This PR makes two changes to the initiative detailed view:

1. When clicked, the initiative marker's tooltip has a new title: “Selected initiative”
2. At the top of the sidebar, the contact email/link is not displayed anymore

## Acceptance criteria

On the detailed view of an initiative:

- There is a way to get information about the map’s initiative
  - After the visitor has clicked on the marker, a tooltip appears with the following content:
    - Title: “Selected initiative”
    - Content: “[INITIATIVE_NAME]”
- There is a way to see the contact email/link in the sidebar
  - Displayed after the “Coordinator” field (only)

## Tracking

[ORC-643](https://vizzuality.atlassian.net/browse/ORC-643)

[ORC-643]: https://vizzuality.atlassian.net/browse/ORC-643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ