### PR TITLE
Fix an issue where the dropdown's icon could overlap its text

### DIFF
--- a/client/src/components/ui/multi-combobox.tsx
+++ b/client/src/components/ui/multi-combobox.tsx
@@ -142,16 +142,18 @@ export const MultiCombobox = <T extends NonNullable<unknown>>({
             onClick={() => setOpen(true)}
             disabled={disabled}
           >
-            {showSelected ? (
-              <span className={cn({ 'max-h-14 max-w-full truncate capitalize': showSelected })}>
-                {selectedLabels}
-              </span>
-            ) : value.length > 0 ? (
-              `${name} (${value.length})`
-            ) : (
-              placeholder ?? name
-            )}
-            <ChevronDown className="absolute right-4 top-2 h-6 w-6 flex-shrink-0" />
+            <span className="truncate">
+              {showSelected ? (
+                <span className={cn({ 'max-h-14 max-w-full truncate capitalize': showSelected })}>
+                  {selectedLabels}
+                </span>
+              ) : value.length > 0 ? (
+                `${name} (${value.length})`
+              ) : (
+                placeholder ?? name
+              )}
+            </span>
+            <ChevronDown className="ml-1 h-6 w-6 flex-shrink-0" />
           </Button>
         )}
         {open && (

--- a/client/src/components/ui/select.tsx
+++ b/client/src/components/ui/select.tsx
@@ -86,7 +86,7 @@ const SelectTrigger = React.forwardRef<
     {children}
     <SelectPrimitive.Icon asChild>
       <ChevronDown
-        className={cn('ml-1 h-6 w-6 transform data-[state=open]:rotate-180', {
+        className={cn('ml-1 h-6 w-6 flex-shrink-0 transform data-[state=open]:rotate-180', {
           'text-gray-700': variant === 'small',
           'text-white': variant === 'default',
         })}


### PR DESCRIPTION
This PR fixes an issue where the down arrow of the dropdowns could overlap their content.

## Testing instructions

### Steps to reproduce

1. Open the Network module
2. Go to the new initiative form
3. Select multiple values in the “Partners” field
4. Close the dropdown

### Result

The selected values appear below the down arrow.

### Expected result

The selected values are not overlapped by the down arrow.

## Tracking

[ORC-648](https://vizzuality.atlassian.net/browse/ORC-648)

[ORC-648]: https://vizzuality.atlassian.net/browse/ORC-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ