### PR TITLE
Address an issue with the info icon on Chrome

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -6,14 +6,23 @@ const nextConfig = {
     return [
       {
         source: '/robots.txt',
-        destination: '/api/robots'
+        destination: '/api/robots',
       },
-    ]
+    ];
   },
   transpilePackages: ['@orcasa/types'],
   webpack(config) {
+    // Match xxx.svg?unoptimized files and load them without any svgo optimization
     config.module.rules.push({
       test: /\.svg$/,
+      resourceQuery: /unoptimized/,
+      use: [{ loader: '@svgr/webpack', options: { svgo: false } }],
+    });
+
+    // Match any other .svg files
+    config.module.rules.push({
+      test: /\.svg$/,
+      resourceQuery: { not: [/unoptimized/] },
       use: ['@svgr/webpack'],
     });
 

--- a/client/public/images/info.svg
+++ b/client/public/images/info.svg
@@ -1,12 +1,5 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="Info" clip-path="url(#clip0_673_7687)">
-<path id="Vector" d="M8.00004 14.6666C11.6819 14.6666 14.6667 11.6818 14.6667 7.99992C14.6667 4.31802 11.6819 1.33325 8.00004 1.33325C4.31814 1.33325 1.33337 4.31802 1.33337 7.99992C1.33337 11.6818 4.31814 14.6666 8.00004 14.6666Z" stroke="#3C4363" stroke-linecap="round" stroke-linejoin="round"/>
-<path id="Vector_2" d="M8 10.6667V8" stroke="#3C4363" stroke-linecap="round" stroke-linejoin="round"/>
-<path id="Vector_3" d="M8 5.33325H8.00667" stroke="#3C4363" stroke-linecap="round" stroke-linejoin="round"/>
-</g>
-<defs>
-<clipPath id="clip0_673_7687">
-<rect width="16" height="16" fill="white"/>
-</clipPath>
-</defs>
+<path id="Vector" d="M8.00004 14.6666C11.6819 14.6666 14.6667 11.6818 14.6667 7.99992C14.6667 4.31802 11.6819 1.33325 8.00004 1.33325C4.31814 1.33325 1.33337 4.31802 1.33337 7.99992C1.33337 11.6818 4.31814 14.6666 8.00004 14.6666Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M8 10.6667V8" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M8 5.33325H8.00667" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/client/src/app/(modules)/network/(form)/new/initiative/page.tsx
+++ b/client/src/app/(modules)/network/(form)/new/initiative/page.tsx
@@ -28,7 +28,7 @@ import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import Alert from '@/styles/icons/alert.svg';
 import Email from '@/styles/icons/email.svg';
-import Info from '@/styles/icons/info.svg';
+import Info from '@/styles/icons/info.svg?unoptimized';
 import Notebook from '@/styles/icons/notebook.svg';
 import Users from '@/styles/icons/users.svg';
 

--- a/client/src/app/(modules)/network/(form)/new/organisation/page.tsx
+++ b/client/src/app/(modules)/network/(form)/new/organisation/page.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { SubmitHandler, useForm } from 'react-hook-form';
 
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { zodResolver } from '@hookform/resolvers/zod';

--- a/client/src/containers/layer-groups-list/item.tsx
+++ b/client/src/containers/layer-groups-list/item.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import Info from 'public/images/info.svg';
+import Info from 'public/images/info.svg?unoptimized';
 
 import { LayerGroupListResponseDataItem } from '@/types/generated/strapi.schemas';
 
@@ -36,7 +36,7 @@ export default function LayerGroupItem(props: Required<LayerGroupListResponseDat
           {description && (
             <Tooltip delayDuration={0} open={infoOpen} onOpenChange={setInfoOpen}>
               <TooltipTrigger asChild onClick={() => setInfoOpen(!infoOpen)}>
-                <Button variant="vanilla" size="auto" className="mr-2 rounded-full">
+                <Button variant="vanilla" size="auto" className="mr-2 rounded-full text-gray-800">
                   <span className="sr-only">Info button</span>
                   <Info className="h-4 w-4" />
                 </Button>

--- a/client/src/containers/layer-groups-list/layers/layer.tsx
+++ b/client/src/containers/layer-groups-list/layers/layer.tsx
@@ -2,7 +2,7 @@
 
 import { ReactElement, cloneElement, useCallback, useMemo } from 'react';
 
-import Info from 'public/images/info.svg';
+import Info from 'public/images/info.svg?unoptimized';
 import Link from 'public/images/link.svg';
 
 import { cn } from '@/lib/classnames';

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -1,3 +1,4 @@
 declare module '*.svg';
+declare module '*.svg?unoptimized';
 declare module '*.png';
 declare module '*.jpg';


### PR DESCRIPTION
This PR addresses an issue where the dot on top of the “i” in the info icon wouldn't be displayed on Chrome.

## Testing instructions

### Steps to reproduce

1. Open the Geospatial data module on Chrome

### Result

- The info button displayed next to the names of the layers is missing the dot on the “i”
- The info button displayed next to the names of the layer groups is missing the dot on the “i”

### Expected result

- Both info buttons have a dot on the “i”.

## Tracking

[ORC-651](https://vizzuality.atlassian.net/browse/ORC-651)

[ORC-651]: https://vizzuality.atlassian.net/browse/ORC-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ