### PR TITLE
[Network] Support URLs with path in the forms

### DIFF
--- a/client/src/app/(modules)/network/(form)/new/initiative/page.tsx
+++ b/client/src/app/(modules)/network/(form)/new/initiative/page.tsx
@@ -131,9 +131,14 @@ export default function ProjectForm() {
         .max(255, {
           message: 'Website is limited to 255 characters.',
         })
-        .regex(new RegExp('^(https?:\\/\\/)?(www\\.)?[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)+\\/?$'), {
-          message: 'Please, enter a valid URL.',
-        })
+        .regex(
+          new RegExp(
+            '^(https?:\\/\\/)?(www\\.)?[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)+(\\/[a-zA-Z0-9-]*)*$',
+          ),
+          {
+            message: 'Please, enter a valid URL.',
+          },
+        )
         .superRefine((value, refinementContext) => {
           const projectCoordinatorEmail = watch('project_coordinator_email');
           if (value && projectCoordinatorEmail) {
@@ -168,9 +173,14 @@ export default function ProjectForm() {
         .max(255, {
           message: 'Website is limited to 255 characters.',
         })
-        .regex(new RegExp('^(https?:\\/\\/)?(www\\.)?[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)+\\/?$'), {
-          message: 'Please, enter a valid URL.',
-        }),
+        .regex(
+          new RegExp(
+            '^(https?:\\/\\/)?(www\\.)?[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)+(\\/[a-zA-Z0-9-]*)*$',
+          ),
+          {
+            message: 'Please, enter a valid URL.',
+          },
+        ),
       type: 'text',
       maxSize: 255,
       description: (

--- a/client/src/app/(modules)/network/(form)/new/organisation/page.tsx
+++ b/client/src/app/(modules)/network/(form)/new/organisation/page.tsx
@@ -167,9 +167,14 @@ export default function OrganisationForm() {
         .max(255, {
           message: 'Organisation name is limited to 255 characters.',
         })
-        .regex(new RegExp('^(https?:\\/\\/)?(www\\.)?[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)+\\/?$'), {
-          message: 'Please, enter a valid URL.',
-        })
+        .regex(
+          new RegExp(
+            '^(https?:\\/\\/)?(www\\.)?[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)+(\\/[a-zA-Z0-9-]*)*$',
+          ),
+          {
+            message: 'Please, enter a valid URL.',
+          },
+        )
         .max(255, {
           message: 'Website is limited to 255 characters.',
         }),


### PR DESCRIPTION
This PR modifies the validation of URLs so that URLs with path can be supported.

## Acceptance criteria

- There is a way to enter URLs with a path in the URL fields
  - Organisation form
    - “Website” field
  - Initiative form
    - “Contact url” field
    - “Website” field
  - Example of URL: `https://www.naturefund.de/en`

## Tracking

[ORC-647](https://vizzuality.atlassian.net/browse/ORC-647)



[ORC-647]: https://vizzuality.atlassian.net/browse/ORC-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ