### PR TITLE
[Practices] Display the description and sub-interventions in the detailed view

### DIFF
--- a/client/src/app/(modules)/practices/[id]/field.tsx
+++ b/client/src/app/(modules)/practices/[id]/field.tsx
@@ -99,7 +99,7 @@ const Field = ({ label, value, description, url, hasEllipsis, logo, formatId }: 
     return url ? (
       renderLink(url)
     ) : (
-      <>
+      <div>
         <div className="flex items-center space-x-2">
           <div
             ref={ref}
@@ -127,11 +127,11 @@ const Field = ({ label, value, description, url, hasEllipsis, logo, formatId }: 
           )}
         </div>
         {isOverTwoLines && (
-          <button onClick={toggleExpanded} className="text-sm font-semibold">
+          <button onClick={toggleExpanded} className="text-sm font-semibold text-purple-400">
             {isExpanded ? 'Show less' : 'Show more'}
           </button>
         )}
-      </>
+      </div>
     );
   };
 

--- a/client/src/app/(modules)/practices/[id]/page.tsx
+++ b/client/src/app/(modules)/practices/[id]/page.tsx
@@ -69,23 +69,25 @@ export default async function PracticeDetails({ params }: PracticeDetailsProps) 
           </a>
         </Button>
       </div>
-      <div className="flex flex-1 flex-col gap-6">
-        <header className="flex gap-2 border-b border-gray-600 pb-1">
-          <NotepadText className="h-6 w-6" />
-          <h2 className="mb-4 font-serif text-xl">Details</h2>
-        </header>
-        {fields.map((field) => (
-          <Field key={field.label} {...field} />
-        ))}
-      </div>
-      <div className="flex flex-1 flex-col gap-6">
-        <header className="flex gap-2 border-b border-gray-600 pb-1">
-          <Tractor className="h-6 w-6" />
-          <h2 className="mb-4 font-serif text-xl">Implementation</h2>
-        </header>
-        {implementationFields.map((field) => (
-          <Field key={field.label} {...field} />
-        ))}
+      <div className="flex flex-col gap-10 lg:basis-2/3 lg:gap-16">
+        <div className="flex flex-1 flex-col gap-6">
+          <header className="flex gap-2 border-b border-gray-600 pb-1">
+            <Tractor className="h-6 w-6" />
+            <h2 className="mb-4 font-serif text-xl">Implementation</h2>
+          </header>
+          {implementationFields.map((field) => (
+            <Field key={field.label} {...field} />
+          ))}
+        </div>
+        <div className="flex flex-1 flex-col gap-6">
+          <header className="flex gap-2 border-b border-gray-600 pb-1">
+            <NotepadText className="h-6 w-6" />
+            <h2 className="mb-4 font-serif text-xl">Details</h2>
+          </header>
+          {fields.map((field) => (
+            <Field key={field.label} {...field} />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/client/src/app/(modules)/practices/[id]/parsers.ts
+++ b/client/src/app/(modules)/practices/[id]/parsers.ts
@@ -8,6 +8,8 @@ import type { FieldType } from './field';
 
 export const getPracticeFields = (practice: Practice): FieldType[] => {
   const {
+    detailed_description: detailedDescription,
+    subinterventions,
     source_name: source,
     language,
     publication_date: publicationDate,
@@ -21,6 +23,14 @@ export const getPracticeFields = (practice: Practice): FieldType[] => {
   } = practice as TypedPractice;
 
   const fields = [];
+
+  if (detailedDescription) {
+    fields.push({
+      label: 'Description',
+      value: detailedDescription,
+      hasEllipsis: true,
+    });
+  }
 
   if (publicationDate) {
     fields.push({
@@ -53,6 +63,20 @@ export const getPracticeFields = (practice: Practice): FieldType[] => {
     fields.push({
       label: `New land use type${landUseTypes?.data?.length > 1 ? 's' : ''}`,
       value: landUseTypes?.data?.map((landUseType) => landUseType.attributes?.name).join(', '),
+    });
+  }
+
+  if (subinterventions && subinterventions.data?.length) {
+    fields.push({
+      label: `Sub-intervention${subinterventions.data.length > 1 ? 's' : ''}`,
+      value: subinterventions.data
+        .map(
+          (subIntervention) =>
+            `${subIntervention.attributes?.name
+              .substr(0, 1)
+              .toUpperCase()}${subIntervention.attributes?.name.substr(1)}`,
+        )
+        .join(', '),
     });
   }
 


### PR DESCRIPTION
This PR displays the description and sub-interventions, when available, in the detailed view of the practices.

## Acceptance criteria

In the detailed view of a practice:

- There is a way to see the detailed description
  - Only displayed if available
- There is a way to see the sub-interventions
  - Only displayed if available
- Design: https://www.figma.com/file/6mRRI8VN5ffn27MjzYpDtx/ORCaSa-Design-v.2-%5BInternal%5D?type=design&node-id=2004-11645&mode=design&t=7kOdd0Mi4hcw2Q2t-4

## Tracking

- [ORC-645](https://vizzuality.atlassian.net/browse/ORC-645) - Display more information in the detailed view of a practice
  - [ORC-650](https://vizzuality.atlassian.net/browse/ORC-650) - FE - Add the detailed description and sub-interventions fields

[ORC-645]: https://vizzuality.atlassian.net/browse/ORC-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ORC-650]: https://vizzuality.atlassian.net/browse/ORC-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ