### PR TITLE
[Network] Highlight the buttons to the organisation/initiative forms

### DIFF
--- a/client/src/components/new-buttons/index.tsx
+++ b/client/src/components/new-buttons/index.tsx
@@ -10,13 +10,13 @@ import { Button } from '@/components/ui/button';
 
 const NewButtons = ({ className }: { className?: string }) => (
   <div className={cn('space-x-4', className)}>
-    <Button asChild>
+    <Button variant="primary" asChild>
       <Link href="/network/new/organisation">
         <Plus className="mr-2 h-4 w-4" />
         Organisation
       </Link>
     </Button>
-    <Button asChild>
+    <Button variant="primary" asChild>
       <Link href="/network/new/initiative">
         <Plus className="mr-2 h-4 w-4" />
         Initiative


### PR DESCRIPTION
This PR changes the variant of the buttons that link to the organisation/initiative forms so that they are highlighted in the Network module.

## Acceptance criteria

- The buttons to create new organisations/initiatives are more visible
  - 🧑‍💻 Use the green primary colour for the buttons

## Tracking

[ORC-655](https://vizzuality.atlassian.net/browse/ORC-655)

[ORC-655]: https://vizzuality.atlassian.net/browse/ORC-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ