### PR TITLE
Improve the responsive design

### DIFF
--- a/client/src/app/(modules)/network/(main)/(details)/layout.tsx
+++ b/client/src/app/(modules)/network/(main)/(details)/layout.tsx
@@ -24,7 +24,15 @@ export default function NetworkModuleDetailsLayout({ children }: { children: Rea
 
   return (
     <>
-      <div className="mt-4 h-[calc(100vh-16px)] space-y-6 overflow-auto bg-gray-700 p-4 pb-6 text-white lg:hidden">
+      <div className="mt-14 h-[calc(100vh-56px)] space-y-6 overflow-auto bg-gray-700 p-4 pb-6 text-white lg:hidden">
+        <SlidingLinkButton
+          href={`/network?${mapSearchParams.toString()}`}
+          variant="dark"
+          Icon={ArrowLeft}
+          scroll={false}
+        >
+          Back to results
+        </SlidingLinkButton>
         {children}
       </div>
       <div className="hidden lg:block">

--- a/client/src/app/(modules)/practices/[id]/layout.tsx
+++ b/client/src/app/(modules)/practices/[id]/layout.tsx
@@ -11,7 +11,15 @@ export default function PracticeDetailsLayout({ children }: { children: React.Re
 
   return (
     <>
-      <div className="mt-[56px] h-[calc(100vh-56px)] overflow-auto bg-gray-700 p-4 pb-6 lg:hidden">
+      <div className="mt-14 h-[calc(100vh-56px)] space-y-6 overflow-auto bg-gray-700 p-4 pb-6 text-white lg:hidden">
+        <SlidingLinkButton
+          href={`/practices?${mapSearchParams.toString()}`}
+          variant="dark"
+          Icon={ArrowLeft}
+          scroll={false}
+        >
+          Back to results
+        </SlidingLinkButton>
         {children}
       </div>
       <div

--- a/client/src/components/home/recommend-section.tsx
+++ b/client/src/components/home/recommend-section.tsx
@@ -45,7 +45,7 @@ export default async function RecommendSection() {
   }
 
   return (
-    <div className="relative mx-4 h-[680px] w-[calc(100%-16px)] lg:mx-0 lg:w-full">
+    <div className="relative mx-4 w-[calc(100%-16px)] pb-8 lg:mx-0 lg:h-[680px] lg:w-full lg:pb-0">
       <div className="absolute hidden h-full w-full items-center justify-center p-10 pt-0 lg:flex">
         <img src="/images/shape3.svg" className="h-[564px] w-full" alt="" />
       </div>

--- a/client/src/components/ui/sliding-link-button.tsx
+++ b/client/src/components/ui/sliding-link-button.tsx
@@ -63,12 +63,12 @@ const SlidingLinkButton = React.forwardRef<
           />
           <span
             className={cn(
-              'text-xs opacity-0 transition group-hover:opacity-100 group-focus:opacity-100',
+              'text-xs transition group-hover:opacity-100 group-focus:opacity-100 lg:opacity-0',
               {
                 'min-w-fit duration-500': !isCompact,
                 'max-w-0 duration-0 group-hover:max-w-fit group-hover:duration-500 group-focus:max-w-fit group-focus:duration-500':
                   isCompact,
-                '-translate-x-1/3 group-hover:translate-x-0 group-focus:translate-x-0':
+                'group-hover:translate-x-0 group-focus:translate-x-0 lg:-translate-x-1/3':
                   position === 'left',
                 'translate-x-0 group-hover:-translate-x-1/4 group-focus:-translate-x-1/4':
                   position === 'right',


### PR DESCRIPTION
This PR improve the responsive design by adding a back link at the top of the detailed view on mobile in the Network and Practices modules and fixing the layout of the homepage's recommendation section.

## Acceptance criteria

- There is a way for the users to go back to the list view once in a detailed view
  - Applies to: Practices, Network
  - 🧑‍💻 Use the desktop back button with the hover style always on
- The “Visit the platform” button at the end of the page is displayed correctly on mobile

## Tracking

[ORC-658](https://vizzuality.atlassian.net/browse/ORC-658)

[ORC-658]: https://vizzuality.atlassian.net/browse/ORC-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ