### PR TITLE
Remove configurable config-sync import

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -77,13 +77,6 @@ The following environment variables are used:
 | DATABASE_PASSWORD       |                                                                                                                                                                                               Database password |              
 | DATABASE_SSL            |                                                                                                                                                    If SSL should be used when connecting to the database server |              
 
-
-The included `Dockerfile` and `Dockerfile.prod` files use an additional configuration option, not present when running in native mode:
-
-| Variable name        |                                                                                                                                                                                                                                            Description |
-|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-| IMPORT_STRAPI_CONFIG | If set to true, the Strapi configuration values in the database will be updated using `yarn config-sync import` on application startup. For more details see [this plugin's](https://market.strapi.io/plugins/strapi-plugin-config-sync) documentation |     
-
 ## Data management
 
 The CMS stores both user data and configuration data in the database. Different types of data are managed in different

--- a/cms/entrypoint.sh
+++ b/cms/entrypoint.sh
@@ -3,7 +3,8 @@ set -e
 
 case "${NODE_ENV}" in
     development)
-        [[ -n $IMPORT_STRAPI_CONFIG ]] && [[ $IMPORT_STRAPI_CONFIG == "true" ]] && echo "Import config" && yarn config-sync import -y
+        echo "Import config"
+        yarn config-sync import -y
         echo "Running Development Server"
         exec yarn dev
         ;;
@@ -12,7 +13,8 @@ case "${NODE_ENV}" in
         exec yarn test
         ;;
     production)
-        [[ -n $IMPORT_STRAPI_CONFIG ]] && [[ $IMPORT_STRAPI_CONFIG == "true" ]] && echo "Import config" && yarn config-sync import -y
+        echo "Import config"
+        yarn config-sync import -y
         echo "Running Production Server"
         exec yarn start
         ;;


### PR DESCRIPTION
This PR removes a conditional execution of `config-sync import` command for docker build used in deploys to staging and production (entrypoint.sh file). (Removing import dependency from the env variable)