### PR TITLE
Send page view events to Matomo when navigating on the client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -41,6 +41,7 @@
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-tooltip": "^1.0.6",
+    "@socialgouv/matomo-next": "^1.9.0",
     "@t3-oss/env-nextjs": "0.4.1",
     "@tanstack/react-query": "^4.29.18",
     "@types/lodash": "^4.14.198",

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -3,7 +3,6 @@ import '@/styles/globals.css';
 import { Suspense } from 'react';
 
 import { Roboto_Slab, Roboto } from 'next/font/google';
-import Script from 'next/script';
 
 import { Metadata } from 'next';
 
@@ -12,6 +11,8 @@ import { cn } from '@/lib/classnames';
 import Providers from '@/app/layout-providers';
 
 import DefaultMapSettings from '@/containers/default-map-settings';
+
+import Matomo from '@/components/utils/matomo';
 
 const roboto = Roboto({
   subsets: ['latin'],
@@ -66,9 +67,6 @@ export const metadata: Metadata = {
   },
 };
 
-const NEXT_PUBLIC_MATOMO_URL = process.env.NEXT_PUBLIC_MATOMO_URL;
-const NEXT_PUBLIC_MATOMO_SITE_ID = process.env.NEXT_PUBLIC_MATOMO_SITE_ID;
-
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <Providers>
@@ -84,29 +82,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           https://nextjs.org/docs/messages/deopted-into-client-rendering */}
           <Suspense fallback={null}>
             <DefaultMapSettings />
+            <Matomo />
           </Suspense>
           {children}
         </body>
-        {NEXT_PUBLIC_MATOMO_URL && NEXT_PUBLIC_MATOMO_SITE_ID && (
-          <Script
-            id="matomo-analytics"
-            dangerouslySetInnerHTML={{
-              __html: `<!-- Matomo -->
-            var _paq = window._paq = window._paq || [];
-            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-            _paq.push(['trackPageView']);
-            _paq.push(['enableLinkTracking']);
-            (function() {
-              var u="${NEXT_PUBLIC_MATOMO_URL}";
-              _paq.push(['setTrackerUrl', u+'matomo.php']);
-              _paq.push(['setSiteId', ${NEXT_PUBLIC_MATOMO_SITE_ID}]);
-              var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-              g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-            })();
-            <!-- End Matomo Code -->`,
-            }}
-          />
-        )}
       </html>
     </Providers>
   );

--- a/client/src/components/utils/matomo.tsx
+++ b/client/src/components/utils/matomo.tsx
@@ -2,14 +2,13 @@
 
 import { useState, useEffect } from 'react';
 
-import { usePathname, useSearchParams } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 
 import { init, push } from '@socialgouv/matomo-next';
 
 import env from '@/env.mjs';
 
 const Matomo = () => {
-  const searchParams = useSearchParams();
   const pathname = usePathname();
 
   const [initialised, setInitialised] = useState(false);
@@ -26,12 +25,9 @@ const Matomo = () => {
   // Send page views
   useEffect(() => {
     if (!pathname) return;
-
-    const url = pathname + (searchParams ? '?' + searchParams.toString() : '');
-
-    push(['setCustomUrl', url]);
+    push(['setCustomUrl', pathname]);
     push(['trackPageView']);
-  }, [pathname, searchParams]);
+  }, [pathname]);
 
   return null;
 };

--- a/client/src/components/utils/matomo.tsx
+++ b/client/src/components/utils/matomo.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+
+import { init, push } from '@socialgouv/matomo-next';
+
+import env from '@/env.mjs';
+
+const Matomo = () => {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const [initialised, setInitialised] = useState(false);
+
+  // Initialize Matomo
+  useEffect(() => {
+    if (env.NEXT_PUBLIC_MATOMO_URL && env.NEXT_PUBLIC_MATOMO_SITE_ID && !initialised) {
+      init({ url: env.NEXT_PUBLIC_MATOMO_URL, siteId: env.NEXT_PUBLIC_MATOMO_SITE_ID });
+    }
+
+    return () => setInitialised(true);
+  }, [initialised, setInitialised]);
+
+  // Send page views
+  useEffect(() => {
+    if (!pathname) return;
+
+    const url = pathname + (searchParams ? '?' + searchParams.toString() : '');
+
+    push(['setCustomUrl', url]);
+    push(['trackPageView']);
+  }, [pathname, searchParams]);
+
+  return null;
+};
+
+export default Matomo;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3018,6 +3018,7 @@ __metadata:
     "@radix-ui/react-switch": "npm:^1.0.3"
     "@radix-ui/react-tabs": "npm:^1.0.4"
     "@radix-ui/react-tooltip": "npm:^1.0.6"
+    "@socialgouv/matomo-next": "npm:^1.9.0"
     "@svgr/webpack": "npm:^8.1.0"
     "@t3-oss/env-nextjs": "npm:0.4.1"
     "@tailwindcss/typography": "npm:0.5.9"
@@ -4160,6 +4161,15 @@ __metadata:
   version: 1.10.2
   resolution: "@rushstack/eslint-patch@npm:1.10.2"
   checksum: 10/a92563ee28aa903ee37f5d34c747a8f5641c0a5a7020881902da8fccf94e208c923ed708aef41989f4b1d328cb4c216166ab108c6c2d72ebf0b5b6c18d1461d0
+  languageName: node
+  linkType: hard
+
+"@socialgouv/matomo-next@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@socialgouv/matomo-next@npm:1.9.0"
+  peerDependencies:
+    next: ">= 9.5.5"
+  checksum: 10/4079c0a377b64ce071939f094578bae55be9ffef3ee2e9d28861131b30623daf1ffe47d44503f2479c29787386ba70f2f8dfdc02b26865bcd8b00a694ddad5e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR changes how Matomo is integrated in the platform so that we can send events when the user navigates on the client.

## Acceptance criteria

- There is a way to track all the pages visited by visitors

## Tracking

[ORC-698](https://vizzuality.atlassian.net/browse/ORC-698)

[ORC-698]: https://vizzuality.atlassian.net/browse/ORC-698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ