### PR TITLE
Feature/chart-organisation-style

### DIFF
--- a/client/src/app/(modules)/practices/[id]/field.tsx
+++ b/client/src/app/(modules)/practices/[id]/field.tsx
@@ -52,7 +52,7 @@ const FieldLink = ({
       <ExternalLink className="ml-2 inline h-4 w-4 min-w-fit" />
     </a>
   ) : (
-    <Link className="text-sm font-semibold leading-7 text-purple-400" href={`${url}`}>
+    <Link className="text-sm font-semibold text-purple-400" href={`${url}`}>
       {children}
     </Link>
   );

--- a/client/src/components/network-diagram/item.tsx
+++ b/client/src/components/network-diagram/item.tsx
@@ -149,6 +149,7 @@ const Item = ({
           {
             'bg-gray-650 text-gray-200': type === 'organization',
             'bg-purple-500 text-white': type === 'project',
+            'bg-green-700 text-white': type === 'organization' && isFirstNode,
           },
         )}
       >


### PR DESCRIPTION
Two little changes
- Display top organisation on the network diagram as green (as in the map)

https://vizzuality.atlassian.net/browse/ORC-695?atlOrigin=eyJpIjoiZGU2NGU5ODdiNmNlNDBlYWJjMjhiZTE3OTEzNmU0ZTAiLCJwIjoiaiJ9

- Remove leading of the links on practice details

https://vizzuality.atlassian.net/browse/ORC-666?atlOrigin=eyJpIjoiZTBiZmM4MDYxNzc1NGMzYWEwYjU0MDZmN2YwNmEwYjIiLCJwIjoiaiJ9