### PR TITLE
[Network] Display all the organisations in green in the diagram

### DIFF
--- a/client/src/components/network-diagram/item.tsx
+++ b/client/src/components/network-diagram/item.tsx
@@ -149,7 +149,7 @@ const Item = ({
           {
             'bg-gray-650 text-gray-200': type === 'organization',
             'bg-purple-500 text-white': type === 'project',
-            'bg-green-700 text-white': type === 'organization' && isFirstNode,
+            'bg-green-700 text-white': type === 'organization',
           },
         )}
       >


### PR DESCRIPTION
This PR makes sure that all the organisations are displayed in green in the diagram and not only the first one.

## Acceptance criteria

In the detailed view of an organisation:

- All the organisations in the diagram have a green background

## Tracking

[ORC-710](https://vizzuality.atlassian.net/browse/ORC-710)

[ORC-710]: https://vizzuality.atlassian.net/browse/ORC-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ